### PR TITLE
fix: remove system paths from Lua package.path

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -104,35 +104,36 @@ int main(int argc, char* argv[])
     QString libExt = "so";
 #endif
 
-    // Build LUA_PATH for Lua modules
+    // Build LUA_PATH for Lua modules (issue #4)
+    // Use only relative paths for portability - no system paths
+    // MUSHclient also includes absolute exe_dir paths (the ! notation in luaconf.h),
+    // but we intentionally omit those to avoid the portability issues they cause
     QStringList luaPaths = {
-        appDir + "/lua/?.lua",
-        appDir + "/lua/?/init.lua",
-        "lua/?.lua",
-        "lua/?/init.lua",
+        "./?.lua",
+        "./lua/?.lua",
+        "./lua/?/init.lua",
     };
-    QString existingLuaPath = QString::fromLocal8Bit(qgetenv("LUA_PATH"));
     QString newLuaPath = luaPaths.join(luaPathSep);
-    if (!existingLuaPath.isEmpty()) {
-        newLuaPath += luaPathSep + existingLuaPath;
-    }
-    newLuaPath += luaPathSep + luaPathSep; // Append ;; to include default paths
     qputenv("LUA_PATH", newLuaPath.toLocal8Bit());
 
     // Build LUA_CPATH for compiled C modules (.so/.dll)
+    // Include app bundle paths for bundled modules (LuaSocket, etc.)
+    // Include relative paths for user modules
+    // No system paths (issue #4)
     QStringList luaCPaths = {
-        appDir + "/lib/?." + libExt,      appDir + "/lib/?/core." + libExt,
-        appDir + "/lib/?/?." + libExt,    appDir + "/lua/?." + libExt,
-        appDir + "/lua/?/core." + libExt, "lib/?." + libExt,
-        "lib/?/core." + libExt,           "lua/?." + libExt,
-        "lua/?/core." + libExt,
+        // App bundle paths (for bundled C modules like LuaSocket)
+        appDir + "/lib/?." + libExt,
+        appDir + "/lib/?/core." + libExt,
+        appDir + "/lua/?." + libExt,
+        appDir + "/lua/?/core." + libExt,
+        // Relative paths (for user C modules)
+        "./lib/?." + libExt,
+        "./lib/?/core." + libExt,
+        "./lua/?." + libExt,
+        "./lua/?/core." + libExt,
+        "./?." + libExt,
     };
-    QString existingLuaCPath = QString::fromLocal8Bit(qgetenv("LUA_CPATH"));
     QString newLuaCPath = luaCPaths.join(luaPathSep);
-    if (!existingLuaCPath.isEmpty()) {
-        newLuaCPath += luaPathSep + existingLuaCPath;
-    }
-    newLuaCPath += luaPathSep + luaPathSep; // Append ;; to include default paths
     qputenv("LUA_CPATH", newLuaCPath.toLocal8Bit());
 
     // Open preferences database


### PR DESCRIPTION
## Summary

Fixes #4 - Lua import path is polluted

The Lua `package.path` was polluted with system paths like `/opt/homebrew/share/lua/5.1/` and app bundle paths. This caused confusion and potential conflicts.

## Changes

- `package.path` now uses ONLY relative paths: `./?.lua`, `./lua/?.lua`, `./lua/?/init.lua`
- `package.cpath` keeps exe dir paths (for bundled LuaSocket, etc.) but removes system paths
- Removed the `;;` suffix that included LuaJIT defaults
- For plugins, only add the plugin's own directory paths

MUSHclient also includes absolute exe_dir paths (the `!` notation in luaconf.h), but we intentionally omit those to avoid the portability issues they cause.

## Result

Before:
```
./?.lua;/opt/homebrew/share/luajit-2.1/?.lua;/usr/local/share/lua/5.1/?.lua;...
```

After:
```
./?.lua;./lua/?.lua;./lua/?/init.lua
```