### PR TITLE
fix: use portable relative paths for default directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,12 +155,17 @@ First run takes ~60 minutes to build Qt. Subsequent builds take ~5 minutes.
 
 ## Configuration
 
-Mushkin uses MUSHclient-compatible paths for easy migration:
+Mushkin uses portable relative paths like the original MUSHclient. By default, all data directories are relative to the current working directory:
 
-**World files, plugins, and logs:**
-- `~/Documents/MUSHclient/` (worlds, plugins, logs subdirectories)
+**Default directories (relative to working directory):**
+- `./worlds/` - World files (.mcl)
+- `./worlds/plugins/` - Plugin files
+- `./worlds/plugins/state/` - Plugin state files
+- `./logs/` - Log files
 
-**Settings:**
+This means you can put Mushkin in any folder and run it from there - all your worlds, plugins, and logs stay together in that folder.
+
+**Settings storage:**
 - macOS: `~/Library/Preferences/com.Gammon.MUSHclient.plist`
 - Linux: `~/.config/Gammon/MUSHclient.conf`
 - Windows: Registry `HKEY_CURRENT_USER\Software\Gammon\MUSHclient`

--- a/src/ui/dialogs/global_preferences_dialog.cpp
+++ b/src/ui/dialogs/global_preferences_dialog.cpp
@@ -22,7 +22,6 @@
 #include <QRadioButton>
 #include <QSpinBox>
 #include <QStackedWidget>
-#include <QStandardPaths>
 #include <QVBoxLayout>
 
 // Helper function to format font info with weight/italic
@@ -1182,9 +1181,8 @@ void GlobalPreferencesDialog::loadSettings()
     Database* db = Database::instance();
 
     // === Worlds Page ===
-    QString defaultWorldsDir =
-        QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation) + "/MUSHclient/worlds";
-    m_worldDirectory->setText(db->getPreference("DefaultWorldFileDirectory", defaultWorldsDir));
+    // Default to relative path like original MUSHclient (resolves relative to working directory)
+    m_worldDirectory->setText(db->getPreference("DefaultWorldFileDirectory", "./worlds/"));
 
     // World list
     QString worldList = db->getPreference("WorldList", "");
@@ -1242,17 +1240,13 @@ void GlobalPreferencesDialog::loadSettings()
     m_autoLogWorld->setChecked(db->getPreferenceInt("AutoLogWorld", 0) != 0);
     m_appendToLogFiles->setChecked(db->getPreferenceInt("AppendToLogFiles", 0) != 0);
     m_confirmLogFileClose->setChecked(db->getPreferenceInt("ConfirmLogFileClose", 1) != 0);
-    QString defaultLogDir =
-        QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation) + "/MUSHclient/logs";
-    m_logDirectory->setText(db->getPreference("DefaultLogFileDirectory", defaultLogDir));
+    // Default to relative path like original MUSHclient
+    m_logDirectory->setText(db->getPreference("DefaultLogFileDirectory", "./logs/"));
 
     // === Plugins Page ===
-    QString defaultPluginsDir =
-        QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation) + "/MUSHclient/plugins";
-    m_pluginsDirectory->setText(db->getPreference("PluginsDirectory", defaultPluginsDir));
-
-    QString defaultStateDir = defaultPluginsDir + "/state";
-    m_stateFilesDirectory->setText(db->getPreference("StateFilesDirectory", defaultStateDir));
+    // Default to relative paths like original MUSHclient
+    m_pluginsDirectory->setText(db->getPreference("PluginsDirectory", "./worlds/plugins/"));
+    m_stateFilesDirectory->setText(db->getPreference("StateFilesDirectory", "./worlds/plugins/state/"));
 
     // Plugin list
     QString pluginList = db->getPreference("PluginList", "");


### PR DESCRIPTION
## Summary

- Change default directory paths from `~/Documents/MUSHclient/` to relative paths matching original MUSHclient behavior
- Paths are now relative to the current working directory, making the installation portable

**Default paths changed:**
- `./worlds/` for world files
- `./worlds/plugins/` for plugins  
- `./worlds/plugins/state/` for plugin state
- `./logs/` for log files

## Details

The original MUSHclient uses relative paths (e.g., `.\worlds\`) that resolve relative to the working directory at startup. This allows users to put MUSHclient in any folder and have all data stay together.

Mushkin was incorrectly defaulting to `~/Documents/MUSHclient/` which breaks this portable behavior.

Fixes #6

## Test plan

- [x] Build compiles successfully
- [x] Verify directories resolve correctly relative to working directory
- [x] Verify existing users with saved preferences continue to work