### PR TITLE
fix: use configured directories for file dialogs

### DIFF
--- a/src/ui/dialogs/command_history_dialog.cpp
+++ b/src/ui/dialogs/command_history_dialog.cpp
@@ -1,21 +1,21 @@
 #include "command_history_dialog.h"
+#include "../../storage/global_options.h"
 #include "../../world/world_document.h"
 
-#include <QVBoxLayout>
-#include <QHBoxLayout>
-#include <QListWidget>
-#include <QLineEdit>
-#include <QPushButton>
 #include <QDialogButtonBox>
-#include <QLabel>
-#include <QInputDialog>
-#include <QMessageBox>
-#include <QFileDialog>
 #include <QFile>
-#include <QTextStream>
-#include <QStandardPaths>
-#include <QShortcut>
+#include <QFileDialog>
+#include <QHBoxLayout>
+#include <QInputDialog>
 #include <QKeySequence>
+#include <QLabel>
+#include <QLineEdit>
+#include <QListWidget>
+#include <QMessageBox>
+#include <QPushButton>
+#include <QShortcut>
+#include <QTextStream>
+#include <QVBoxLayout>
 
 CommandHistoryDialog::CommandHistoryDialog(WorldDocument* doc, QWidget* parent)
     : QDialog(parent)
@@ -277,12 +277,11 @@ void CommandHistoryDialog::saveToFile()
     if (!m_doc)
         return;
 
+    // Use configured log directory (matches original MUSHclient behavior)
+    QString logDir = GlobalOptions::instance()->defaultLogFileDirectory();
     QString filename = QFileDialog::getSaveFileName(
-        this,
-        "Save Command History",
-        QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation) + "/command_history.txt",
-        "Text Files (*.txt);;All Files (*)"
-    );
+        this, "Save Command History", logDir + "/command_history.txt",
+        "Text Files (*.txt);;All Files (*)");
 
     if (filename.isEmpty())
         return;

--- a/src/ui/dialogs/plugin_wizard.cpp
+++ b/src/ui/dialogs/plugin_wizard.cpp
@@ -3,6 +3,7 @@
 #include "automation/timer.h"
 #include "automation/trigger.h"
 #include "automation/variable.h"
+#include "storage/global_options.h"
 #include "world/world_document.h"
 
 #include <QDateTime>
@@ -15,7 +16,6 @@
 #include <QHeaderView>
 #include <QMessageBox>
 #include <QRegularExpression>
-#include <QStandardPaths>
 #include <QTextStream>
 #include <QUuid>
 #include <QVBoxLayout>
@@ -1106,12 +1106,8 @@ bool PluginWizard::savePluginXml(const QString& xml)
     QString pluginName = field("name").toString();
     QString suggestedFilename = pluginName + ".xml";
 
-    // Get plugins directory (or use home directory)
-    QString pluginDir = QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation);
-    QDir dir(pluginDir);
-    if (dir.exists("MUSHclient/plugins")) {
-        pluginDir = dir.filePath("MUSHclient/plugins");
-    }
+    // Use configured plugins directory (matches original MUSHclient behavior)
+    QString pluginDir = GlobalOptions::instance()->pluginsDirectory();
 
     // File save dialog
     QString filename = QFileDialog::getSaveFileName(this, tr("Save Plugin As"),

--- a/src/ui/main_window.cpp
+++ b/src/ui/main_window.cpp
@@ -1,6 +1,7 @@
 #include "main_window.h"
 #include "../automation/plugin.h" // For plugin callback constants
 #include "../storage/database.h"
+#include "../storage/global_options.h"
 #include "../text/line.h"
 #include "../world/notepad_widget.h"
 #include "../world/world_document.h"
@@ -1685,10 +1686,11 @@ void MainWindow::newWorld()
 
 void MainWindow::openWorld()
 {
+    // Use configured world directory (matches original MUSHclient behavior)
+    QString startDir = GlobalOptions::instance()->defaultWorldFileDirectory();
+
     QString filename = QFileDialog::getOpenFileName(
-        this, "Open World File",
-        QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation),
-        "MUSHclient World Files (*.mcl);;All Files (*)");
+        this, "Open World File", startDir, "MUSHclient World Files (*.mcl);;All Files (*)");
 
     if (!filename.isEmpty()) {
         openWorld(filename);
@@ -1799,10 +1801,10 @@ void MainWindow::saveWorld()
 
     // If no filename (new world), prompt for one (Save As behavior)
     if (filename.isEmpty()) {
+        // Use configured world directory (matches original MUSHclient behavior)
+        QString startDir = GlobalOptions::instance()->defaultWorldFileDirectory();
         filename = QFileDialog::getSaveFileName(
-            this, "Save World File",
-            QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation),
-            "MUSHclient World Files (*.mcl);;All Files (*)");
+            this, "Save World File", startDir, "MUSHclient World Files (*.mcl);;All Files (*)");
 
         if (filename.isEmpty()) {
             return; // User cancelled
@@ -1832,10 +1834,10 @@ void MainWindow::saveWorldAs()
         return;
     }
 
+    // Use configured world directory (matches original MUSHclient behavior)
+    QString startDir = GlobalOptions::instance()->defaultWorldFileDirectory();
     QString filename = QFileDialog::getSaveFileName(
-        this, "Save World File As",
-        QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation),
-        "MUSHclient World Files (*.mcl);;All Files (*)");
+        this, "Save World File As", startDir, "MUSHclient World Files (*.mcl);;All Files (*)");
 
     if (filename.isEmpty()) {
         return;
@@ -1906,9 +1908,10 @@ void MainWindow::toggleLogSession()
                                   .arg(worldWidget->worldName())
                                   .arg(QDateTime::currentDateTime().toString("yyyyMMdd_HHmmss"));
 
+        // Use configured log directory (matches original MUSHclient behavior)
+        QString logDir = GlobalOptions::instance()->defaultLogFileDirectory();
         QString filename = QFileDialog::getSaveFileName(
-            this, "Save Log File",
-            QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation) + "/" + defaultName,
+            this, "Save Log File", logDir + "/" + defaultName,
             "Log Files (*.log *.txt);;All Files (*)");
 
         if (filename.isEmpty()) {

--- a/src/ui/widgets/activity_window.cpp
+++ b/src/ui/widgets/activity_window.cpp
@@ -5,10 +5,10 @@
 #include <QMdiArea>
 #include <QMdiSubWindow>
 #include <QMenu>
-#include <QStandardPaths>
 #include <QVBoxLayout>
 
 #include "../../storage/database.h"
+#include "../../storage/global_options.h"
 #include "../main_window.h"
 #include "../views/world_widget.h"
 #include "world_document.h"
@@ -346,10 +346,10 @@ void ActivityWindow::saveWorldAs()
     if (!ww)
         return;
 
+    // Use configured world directory (matches original MUSHclient behavior)
+    QString startDir = GlobalOptions::instance()->defaultWorldFileDirectory();
     QString filename = QFileDialog::getSaveFileName(
-        this, tr("Save World As"),
-        QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation),
-        tr("MUSHclient World Files (*.mcl);;All Files (*)"));
+        this, tr("Save World As"), startDir, tr("MUSHclient World Files (*.mcl);;All Files (*)"));
 
     if (!filename.isEmpty()) {
         ww->saveToFile(filename);


### PR DESCRIPTION
## Summary

- Replace hardcoded `~/Documents` paths with configured directories in all file dialogs
- Open/Save World dialogs now use `DefaultWorldFileDirectory` (default: `./worlds/`)
- Log file dialogs now use `DefaultLogFileDirectory` (default: `./logs/`)
- Plugin wizard now uses `PluginsDirectory` (default: `./worlds/plugins/`)
- Command history save uses log directory (Mushkin enhancement, not in original)

## Verification Against Original MUSHclient

Checked original source to confirm correct directory usage:
- `mainfrm.cpp:1687` - Open World uses `App.m_strDefaultWorldFileDirectory`
- `ActivityDoc.cpp:97` - Activity window uses `App.m_strDefaultWorldFileDirectory`
- `plugins.cpp:966` - Plugin save uses `App.m_strPluginsDirectory`
- `prefspropertypages.cpp:1155` - Log file uses `App.m_strDefaultLogFileDirectory`

Fixes #1

## Test plan

- [ ] Open World dialog starts in `./worlds/` (or configured directory)
- [ ] Save World As dialog starts in `./worlds/`
- [ ] Log Session dialog starts in `./logs/`
- [ ] Plugin wizard save starts in `./worlds/plugins/`