### PR TITLE
fix: correct font sizing on macOS to match Windows

### DIFF
--- a/src/ui/views/input_view.cpp
+++ b/src/ui/views/input_view.cpp
@@ -1,5 +1,6 @@
 #include "input_view.h"
 #include "../../automation/plugin.h"
+#include "../../utils/font_utils.h"
 #include "../../world/color_utils.h"
 #include "../../world/lua_api/lua_registration.h"
 #include "../../world/script_engine.h"
@@ -342,8 +343,8 @@ void InputView::applyInputSettings()
         return;
     }
 
-    // Apply font settings
-    QFont inputFont(m_doc->m_input_font_name, m_doc->m_input_font_height);
+    // Apply font settings (uses createMUSHclientFont for Windows-compatible sizing on macOS)
+    QFont inputFont = createMUSHclientFont(m_doc->m_input_font_name, m_doc->m_input_font_height);
     inputFont.setItalic(m_doc->m_input_font_italic);
     inputFont.setWeight(static_cast<QFont::Weight>(m_doc->m_input_font_weight));
     setFont(inputFont);

--- a/src/ui/views/output_view.cpp
+++ b/src/ui/views/output_view.cpp
@@ -1,5 +1,6 @@
 #include "output_view.h"
 #include "../../text/action.h"
+#include "../../utils/font_utils.h"
 #include "../../world/color_utils.h"
 #include "../../world/miniwindow.h"
 #include "../automation/plugin.h"
@@ -50,12 +51,13 @@ OutputView::OutputView(WorldDocument* doc, QWidget* parent)
 {
     // Set up fixed-width font for MUD display
     // Read font from WorldDocument if available, otherwise use default
+    // Uses createMUSHclientFont() for Windows-compatible sizing on macOS
     if (m_doc && !m_doc->m_font_name.isEmpty()) {
-        m_font = QFont(m_doc->m_font_name, m_doc->m_font_height);
+        m_font = createMUSHclientFont(m_doc->m_font_name, m_doc->m_font_height);
         qCDebug(lcUI) << "OutputView: Using font from WorldDocument:" << m_doc->m_font_name
                       << m_doc->m_font_height;
     } else {
-        m_font = QFont("Courier New", 10);
+        m_font = createMUSHclientFont("Courier New", 10);
         qCDebug(lcUI) << "OutputView: Using default font (Courier New, 10)";
     }
     m_font.setFixedPitch(true);

--- a/src/ui/views/world_widget.cpp
+++ b/src/ui/views/world_widget.cpp
@@ -1,5 +1,6 @@
 #include "world_widget.h"
 #include "../../automation/plugin.h"         // For plugin callback constants
+#include "../../utils/font_utils.h"          // For Windows-compatible font sizing
 #include "../../world/accelerator_manager.h" // For keyboard shortcuts
 #include "../../world/miniwindow.h"          // For miniwindow signal connection
 #include "../world/world_document.h"
@@ -182,7 +183,7 @@ void WorldWidget::setupUi()
 
     // Connect output settings signal
     connect(m_document, &WorldDocument::outputSettingsChanged, this, [this]() {
-        QFont font(m_document->m_font_name, m_document->m_font_height);
+        QFont font = createMUSHclientFont(m_document->m_font_name, m_document->m_font_height);
         m_outputView->setOutputFont(font);
     });
 
@@ -381,7 +382,7 @@ bool WorldWidget::loadFromFile(const QString& filename)
     // Apply loaded settings to views (fonts, colors, etc.)
     // This triggers the output and input views to refresh with the new settings from the XML
     if (m_outputView && m_document) {
-        QFont font(m_document->m_font_name, m_document->m_font_height);
+        QFont font = createMUSHclientFont(m_document->m_font_name, m_document->m_font_height);
         m_outputView->setOutputFont(font);
     }
     if (m_inputView && m_document) {

--- a/src/utils/font_utils.h
+++ b/src/utils/font_utils.h
@@ -1,0 +1,37 @@
+#ifndef FONT_UTILS_H
+#define FONT_UTILS_H
+
+#include <QFont>
+#include <QtGlobal>
+
+/**
+ * @brief Create a QFont with Windows-compatible sizing
+ *
+ * MUSHclient world files store font sizes as point sizes assuming Windows 96 DPI.
+ * On macOS (72 DPI logical), Qt would render these fonts ~25% smaller.
+ *
+ * This function converts the point size to pixel size on macOS to match
+ * Windows rendering, while using native point sizing on Windows/Linux.
+ *
+ * @param family Font family name
+ * @param pointSize Point size (as stored in MUSHclient world files)
+ * @return QFont configured for Windows-compatible rendering
+ */
+inline QFont createMUSHclientFont(const QString& family, int pointSize)
+{
+    QFont font(family);
+
+#ifdef Q_OS_MACOS
+    // macOS uses 72 DPI logical, but MUSHclient assumes Windows 96 DPI
+    // Convert: pixelSize = pointSize * 96 / 72
+    int pixelSize = qRound(pointSize * 96.0 / 72.0);
+    font.setPixelSize(pixelSize > 0 ? pixelSize : 1);
+#else
+    // Windows/Linux: use point size directly
+    font.setPointSize(pointSize > 0 ? pointSize : 1);
+#endif
+
+    return font;
+}
+
+#endif // FONT_UTILS_H


### PR DESCRIPTION
## Summary

Fonts on macOS were displaying ~25% smaller than on Windows MUSHclient due to DPI differences.

**Root cause:**
- MUSHclient world files store font sizes as point sizes assuming Windows 96 DPI
- macOS uses 72 DPI logical, so Qt renders fonts smaller
- Same "10pt" font = 13 pixels on Windows vs 10 pixels on macOS

**Fix:**
- Add `createMUSHclientFont()` helper in `src/utils/font_utils.h`
- On macOS, convert point sizes to pixel sizes: `pixelSize = pointSize * 96 / 72`
- On Windows/Linux, use native point sizing

This matches the existing fix in `miniwindow.cpp:982-991` for plugin fonts.

Fixes #2

## Test plan

- [x] Build compiles successfully
- [ ] Fonts display at same physical size as Windows MUSHclient
- [ ] Input and output views both use correct sizing