### PR TITLE
docs: use brew for aqtinstall on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   QT_VERSION: "6.9.3"
 
@@ -54,13 +58,12 @@ jobs:
       - name: Install dependencies (macOS)
         if: matrix.os == 'macOS'
         run: |
-          brew install cmake ninja pcre luajit sqlite openssl
-          pip3 install aqtinstall --break-system-packages
+          brew install cmake ninja pcre luajit sqlite openssl aqtinstall
 
       - name: Install Qt (macOS)
         if: matrix.os == 'macOS'
         run: |
-          python3 -m aqt install-qt mac desktop ${{ env.QT_VERSION }} -m qtmultimedia --outputdir $HOME/Qt
+          aqt install-qt mac desktop ${{ env.QT_VERSION }} -m qtmultimedia --outputdir $HOME/Qt
           echo "Qt6_DIR=$HOME/Qt/${{ env.QT_VERSION }}/macos/lib/cmake/Qt6" >> $GITHUB_ENV
           echo "$HOME/Qt/${{ env.QT_VERSION }}/macos/bin" >> $GITHUB_PATH
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,8 +47,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          brew install cmake ninja pcre luajit sqlite openssl
-          pip3 install aqtinstall --break-system-packages
+          brew install cmake ninja pcre luajit sqlite openssl aqtinstall
 
       - name: Cache Qt Static
         id: cache-qt

--- a/README.md
+++ b/README.md
@@ -30,8 +30,7 @@ For contributors and active development. This build links dynamically against Qt
 ```bash
 # Prerequisites
 xcode-select --install
-brew install cmake ninja pcre luajit sqlite openssl
-pip3 install aqtinstall
+brew install cmake ninja pcre luajit sqlite openssl aqtinstall
 
 # Clone and build
 git clone https://github.com/justinpopa/mushkin.git
@@ -48,8 +47,7 @@ open build/mushkin.app
 ```bash
 # Prerequisites
 xcode-select --install
-brew install cmake ninja pcre luajit sqlite openssl
-pip3 install aqtinstall
+brew install cmake ninja pcre luajit sqlite openssl aqtinstall
 
 # Build (first run ~60 min for Qt, subsequent runs ~2 min)
 git clone https://github.com/justinpopa/mushkin.git


### PR DESCRIPTION
Consolidate macOS prerequisites to use Homebrew for aqtinstall instead of pip3.

Closes #24