### PR TITLE
feat: macOS app bundle directory support

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,6 +2,7 @@
 #include "storage/global_options.h"
 #include "ui/lua_dialog_registration.h"
 #include "ui/main_window.h"
+#include "utils/app_paths.h"
 #include "utils/logging.h"
 #include <QApplication>
 #include <QDir>
@@ -24,7 +25,7 @@ Q_IMPORT_PLUGIN(QWindowsIntegrationPlugin)
 // Note: .fon (Windows bitmap fonts) are NOT supported by Qt on macOS/Linux
 static void loadLocalFonts()
 {
-    QString appDir = QCoreApplication::applicationDirPath();
+    QString appDir = AppPaths::getAppDirectory();
 
     // Font file extensions that Qt supports
     QStringList fontExtensions = {"*.ttf", "*.otf", "*.ttc"};
@@ -99,7 +100,7 @@ int main(int argc, char* argv[])
     // Set up LUA_PATH and LUA_CPATH environment variables for Lua module loading
     // This is critical for llthreads2 and other libraries that create fresh Lua states,
     // as they don't inherit our custom package.path settings from script_engine.cpp
-    QString appDir = QCoreApplication::applicationDirPath();
+    QString exeDir = AppPaths::getExecutableDirectory();
 #ifdef Q_OS_WIN
     QString luaPathSep = ";";
     QString libExt = "dll";
@@ -123,11 +124,11 @@ int main(int argc, char* argv[])
     // Include relative paths for user modules
     // No system paths (issue #4)
     QStringList luaCPaths = {
-        // App bundle paths (for bundled C modules like LuaSocket)
-        appDir + "/lib/?." + libExt,
-        appDir + "/lib/?/core." + libExt,
-        appDir + "/lua/?." + libExt,
-        appDir + "/lua/?/core." + libExt,
+        // Executable paths (for bundled C modules like LuaSocket)
+        exeDir + "/lib/?." + libExt,
+        exeDir + "/lib/?/core." + libExt,
+        exeDir + "/lua/?." + libExt,
+        exeDir + "/lua/?/core." + libExt,
         // Relative paths (for user C modules)
         "./lib/?." + libExt,
         "./lib/?/core." + libExt,

--- a/src/storage/database.cpp
+++ b/src/storage/database.cpp
@@ -1,5 +1,6 @@
 #include "storage/database.h"
 
+#include "../utils/app_paths.h"
 #include "logging.h"
 #include <QCoreApplication>
 #include <QDebug>
@@ -51,7 +52,7 @@ bool Database::open()
 
     if (!QFile::exists(m_dbPath)) {
         // Fall back to application directory
-        m_dbPath = QCoreApplication::applicationDirPath() + "/" + filename;
+        m_dbPath = AppPaths::getAppDirectory() + "/" + filename;
         qCDebug(lcStorage) << "Trying application directory:" << m_dbPath;
     }
 

--- a/src/ui/main_window.cpp
+++ b/src/ui/main_window.cpp
@@ -1,6 +1,7 @@
 #include "main_window.h"
 #include "../automation/plugin.h" // For plugin callback constants
 #include "../storage/database.h"
+#include "../utils/app_paths.h"
 #include "../storage/global_options.h"
 #include "../text/line.h"
 #include "../world/notepad_widget.h"
@@ -1678,7 +1679,7 @@ void MainWindow::openStartupWorlds()
             // Resolve relative paths relative to the application directory
             // (e.g., "./worlds/Aardwolf.mcl" or "worlds/Aardwolf.mcl")
             if (!QDir::isAbsolutePath(trimmedPath)) {
-                trimmedPath = QCoreApplication::applicationDirPath() + "/" + trimmedPath;
+                trimmedPath = AppPaths::getAppDirectory() + "/" + trimmedPath;
             }
 
             // Clean up the path (resolve . and ..)

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -1,4 +1,6 @@
 add_library(utils STATIC
+    app_paths.cpp
+    app_paths.h
     name_generator.cpp
     name_generator.h
     logging.cpp

--- a/src/utils/app_paths.cpp
+++ b/src/utils/app_paths.cpp
@@ -1,0 +1,32 @@
+#include "app_paths.h"
+#include <QCoreApplication>
+#include <QDir>
+
+namespace AppPaths {
+
+QString getAppDirectory()
+{
+    QString path = QCoreApplication::applicationDirPath();
+
+#ifdef Q_OS_MAC
+    // If inside a .app bundle, go up to where the .app lives
+    // Bundle structure: /path/to/mushkin.app/Contents/MacOS/mushkin
+    // We want: /path/to/
+    if (path.contains(".app/Contents/MacOS")) {
+        QDir dir(path);
+        dir.cdUp(); // MacOS -> Contents
+        dir.cdUp(); // Contents -> mushkin.app
+        dir.cdUp(); // mushkin.app -> containing folder
+        return dir.absolutePath();
+    }
+#endif
+
+    return path;
+}
+
+QString getExecutableDirectory()
+{
+    return QCoreApplication::applicationDirPath();
+}
+
+} // namespace AppPaths

--- a/src/utils/app_paths.h
+++ b/src/utils/app_paths.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <QString>
+
+namespace AppPaths {
+
+// Returns the base directory for application data (worlds, lua, plugins, etc.)
+//
+// On macOS .app bundles, this returns the directory containing the .app bundle,
+// allowing users to place mushkin.app alongside their worlds/ and lua/ folders.
+//
+// On standalone binaries (all platforms), this returns the directory containing
+// the executable.
+QString getAppDirectory();
+
+// Returns the directory containing the actual executable binary.
+// Use this for resources that must be alongside the binary itself (e.g., bundled
+// C libraries in lib/).
+QString getExecutableDirectory();
+
+} // namespace AppPaths

--- a/src/world/lua_api/world_settings.cpp
+++ b/src/world/lua_api/world_settings.cpp
@@ -9,6 +9,7 @@
 
 #include "../../automation/plugin.h"
 #include "../../storage/database.h"
+#include "../../utils/app_paths.h"
 #include "../../world/config_options.h"
 #include "../../world/view_interfaces.h"
 #include "../../world/world_document.h"
@@ -677,9 +678,9 @@ int L_GetInfo(lua_State* L)
             lua_pushstring(L, "");
         } break;
 
-        case 59: // Scripts directory (executable directory)
+        case 59: // Scripts directory (application directory)
         {
-            QString appDir = QCoreApplication::applicationDirPath();
+            QString appDir = AppPaths::getAppDirectory();
             if (!appDir.isEmpty() && !appDir.endsWith("/")) {
                 appDir += "/";
             }
@@ -696,7 +697,7 @@ int L_GetInfo(lua_State* L)
 
             // If relative, resolve against application directory
             if (!QDir::isAbsolutePath(pluginsDir)) {
-                QString appDir = QCoreApplication::applicationDirPath();
+                QString appDir = AppPaths::getAppDirectory();
                 pluginsDir = QDir(appDir).absoluteFilePath(pluginsDir);
             }
             pluginsDir = QDir::cleanPath(pluginsDir);
@@ -746,9 +747,10 @@ int L_GetInfo(lua_State* L)
 
         case 66: // MUSHclient application directory
         {
-            // Return the directory containing the application executable
+            // Return the application directory (where user files like worlds/ are located)
+            // On macOS .app bundles, this is the folder containing the .app bundle
             // Based on: ExtractDirectory(App.m_strMUSHclientFileName)
-            QString appDir = QCoreApplication::applicationDirPath();
+            QString appDir = AppPaths::getAppDirectory();
             // Ensure trailing slash for compatibility
             if (!appDir.isEmpty() && !appDir.endsWith("/")) {
                 appDir += "/";
@@ -803,7 +805,7 @@ int L_GetInfo(lua_State* L)
 
         case 74: // Sounds directory
         {
-            QString soundsDir = QCoreApplication::applicationDirPath();
+            QString soundsDir = AppPaths::getAppDirectory();
             if (!soundsDir.isEmpty() && !soundsDir.endsWith("/")) {
                 soundsDir += "/";
             }

--- a/src/world/lua_api/world_utilities.cpp
+++ b/src/world/lua_api/world_utilities.cpp
@@ -5,6 +5,7 @@
 #include "../../automation/alias.h"
 #include "../../automation/trigger.h"
 #include "../../storage/database.h"
+#include "../../utils/app_paths.h"
 #include "../../utils/name_generator.h"
 #include "../accelerator_manager.h"
 #include "../lua_dialog_callbacks.h"
@@ -4675,7 +4676,7 @@ int L_Save(lua_State* L)
 
         // Resolve relative path against application directory
         if (!QDir::isAbsolutePath(defaultDir)) {
-            defaultDir = QDir(QCoreApplication::applicationDirPath()).absoluteFilePath(defaultDir);
+            defaultDir = QDir(AppPaths::getAppDirectory()).absoluteFilePath(defaultDir);
         }
 
         // Create suggested filename from world name (sanitize invalid characters)

--- a/src/world/lua_utils.cpp
+++ b/src/world/lua_utils.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "lua_api/lua_common.h"
+#include "../utils/app_paths.h"
 #include "color_utils.h"
 #include "lua_dialog_callbacks.h"
 #include "script_engine.h"
@@ -1185,7 +1186,7 @@ static int L_utils_info(lua_State* L)
     lua_rawset(L, -3);
 
     // Application directory
-    QString appDir = QCoreApplication::applicationDirPath();
+    QString appDir = AppPaths::getAppDirectory();
     lua_pushstring(L, "app_directory");
     lua_pushstring(L, appDir.toUtf8().constData());
     lua_rawset(L, -3);

--- a/src/world/script_engine.cpp
+++ b/src/world/script_engine.cpp
@@ -1,5 +1,6 @@
 #include "script_engine.h"
 #include "../automation/plugin.h"
+#include "../utils/app_paths.h"
 #include "../world/world_document.h"
 #include <QCoreApplication>
 #include <QDebug>
@@ -282,9 +283,10 @@ void ScriptEngine::openLua()
 
     // 5b. Set up Lua package.cpath for compiled C modules (issue #4)
     // We replace the default cpath entirely - no system paths
-    // App bundle paths are needed for bundled modules like LuaSocket
+    // Executable paths are needed for bundled modules like LuaSocket
     lua_getglobal(L, "package");
 
+    QString exeDir = AppPaths::getExecutableDirectory();
 #ifdef Q_OS_WIN
     QString libExt = "dll";
 #else
@@ -292,11 +294,11 @@ void ScriptEngine::openLua()
 #endif
 
     QStringList luaCPaths = {
-        // App bundle paths (for bundled C modules like LuaSocket)
-        appDir + "/lib/?." + libExt,
-        appDir + "/lib/?/core." + libExt,
-        appDir + "/lua/?." + libExt,
-        appDir + "/lua/?/core." + libExt,
+        // Executable paths (for bundled C modules like LuaSocket)
+        exeDir + "/lib/?." + libExt,
+        exeDir + "/lib/?/core." + libExt,
+        exeDir + "/lua/?." + libExt,
+        exeDir + "/lua/?/core." + libExt,
         // Relative paths (for user C modules)
         "./lib/?." + libExt,
         "./lib/?/core." + libExt,
@@ -662,7 +664,7 @@ return re
     // We wrap io.open, dofile, and loadfile to transparently convert separators
     // Also try application's lua/ directory for files not found at relative path
     // Note: Pass app_dir as a global to avoid string escaping issues
-    QString normalizedAppDir = appDir;
+    QString normalizedAppDir = AppPaths::getAppDirectory();
     normalizedAppDir.replace('\\', '/');
     lua_pushstring(L, normalizedAppDir.toUtf8().constData());
     lua_setglobal(L, "_MUSHCLIENT_APP_DIR");

--- a/src/world/world_logging.cpp
+++ b/src/world/world_logging.cpp
@@ -18,6 +18,7 @@
 #include "color_utils.h"
 #include "logging.h"
 #include "world_document.h"
+#include "../utils/app_paths.h"
 #include <QCoreApplication>
 #include <QDateTime>
 #include <QDebug>
@@ -104,7 +105,7 @@ QString WorldDocument::FormatTime(const QDateTime& dt, const QString& pattern, b
 
     // %F becomes default world files directory
     // TODO: Get from application settings when implemented
-    QString worldFilesDir = QCoreApplication::applicationDirPath() + "/worlds";
+    QString worldFilesDir = AppPaths::getAppDirectory() + "/worlds";
     if (forHTML) {
         worldFilesDir = FixHTMLString(worldFilesDir);
     }
@@ -112,7 +113,7 @@ QString WorldDocument::FormatTime(const QDateTime& dt, const QString& pattern, b
 
     // %L becomes default log files directory
     // TODO: Get from application settings when implemented
-    QString logFilesDir = QCoreApplication::applicationDirPath() + "/logs";
+    QString logFilesDir = AppPaths::getAppDirectory() + "/logs";
     if (forHTML) {
         logFilesDir = FixHTMLString(logFilesDir);
     }

--- a/src/world/xml_serialization.cpp
+++ b/src/world/xml_serialization.cpp
@@ -8,6 +8,7 @@
 
 #include "xml_serialization.h"
 #include "../storage/database.h"
+#include "../utils/app_paths.h"
 #include "config_options.h"
 #include "logging.h"
 #include "plugin.h" // For Plugin member access
@@ -58,7 +59,7 @@ QString resolvePluginPath(const QString& pluginPath, const QString& worldFilePat
     // If pluginsDir is relative, resolve against application directory
     // (where the binary is located, not current working directory)
     if (!QDir::isAbsolutePath(pluginsDir)) {
-        pluginsDir = QDir(QCoreApplication::applicationDirPath()).absoluteFilePath(pluginsDir);
+        pluginsDir = QDir(AppPaths::getAppDirectory()).absoluteFilePath(pluginsDir);
     }
 
     // Clean up the path (removes . and .., normalizes slashes)
@@ -67,7 +68,7 @@ QString resolvePluginPath(const QString& pluginPath, const QString& worldFilePat
     // Handle special placeholders (like original MUSHclient)
     path.replace("$PLUGINSDEFAULTDIR", QDir(pluginsDir).absolutePath());
     path.replace("$WORLDDIR", worldDir);
-    path.replace("$PROGRAMDIR", QCoreApplication::applicationDirPath());
+    path.replace("$PROGRAMDIR", AppPaths::getAppDirectory());
 
     // If absolute after placeholder replacement, use directly
     if (QDir::isAbsolutePath(path)) {


### PR DESCRIPTION
Add AppPaths utility for proper directory resolution when running as macOS .app bundle.

- `getAppDirectory()` returns folder containing .app (or exe for standalone)
- `getExecutableDirectory()` returns folder containing actual binary

Users can now place mushkin.app alongside their worlds/ folder.

Closes #19