### PR TITLE
fix: Connection menu order and shortcuts

### DIFF
--- a/src/ui/main_window.cpp
+++ b/src/ui/main_window.cpp
@@ -374,13 +374,21 @@ void MainWindow::createMenus()
     // Connection Menu (matches original MUSHclient structure)
     QMenu* connectionMenu = menuBar()->addMenu("Connecti&on");
 
+    // Quick Connect first (also in File menu)
+    QAction* quickConnectAction2 = connectionMenu->addAction("&Quick Connect...");
+    quickConnectAction2->setShortcut(QKeySequence(Qt::CTRL | Qt::ALT | Qt::SHIFT | Qt::Key_K));
+    quickConnectAction2->setStatusTip("Quickly connect to a MUD server");
+    connect(quickConnectAction2, &QAction::triggered, this, &MainWindow::quickConnect);
+
+    connectionMenu->addSeparator();
+
     m_connectAction = connectionMenu->addAction("&Connect");
-    m_connectAction->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_G));
+    m_connectAction->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_K));
     m_connectAction->setStatusTip("Connect to the MUD server");
     connect(m_connectAction, &QAction::triggered, this, &MainWindow::connectToMud);
 
     m_disconnectAction = connectionMenu->addAction("&Disconnect");
-    m_disconnectAction->setShortcut(QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_G));
+    m_disconnectAction->setShortcut(QKeySequence(Qt::SHIFT | Qt::CTRL | Qt::Key_K));
     m_disconnectAction->setStatusTip("Disconnect from the MUD server");
     connect(m_disconnectAction, &QAction::triggered, this, &MainWindow::disconnectFromMud);
 
@@ -392,7 +400,7 @@ void MainWindow::createMenus()
     m_autoConnectAction->setMenuRole(QAction::NoRole);
     connect(m_autoConnectAction, &QAction::triggered, this, &MainWindow::toggleAutoConnect);
 
-    m_reconnectOnDisconnectAction = connectionMenu->addAction("&Reconnect on Disconnect");
+    m_reconnectOnDisconnectAction = connectionMenu->addAction("&Reconnect On Disconnect");
     m_reconnectOnDisconnectAction->setCheckable(true);
     m_reconnectOnDisconnectAction->setStatusTip("Automatically reconnect when disconnected");
     m_reconnectOnDisconnectAction->setMenuRole(QAction::NoRole);
@@ -401,11 +409,12 @@ void MainWindow::createMenus()
 
     connectionMenu->addSeparator();
 
-    m_connectToAllAction = connectionMenu->addAction("Connect to All &Open Worlds");
+    m_connectToAllAction = connectionMenu->addAction("Connect to All Open &Worlds");
+    m_connectToAllAction->setShortcut(QKeySequence(Qt::CTRL | Qt::ALT | Qt::Key_K));
     m_connectToAllAction->setStatusTip("Connect to all open but disconnected worlds");
     connect(m_connectToAllAction, &QAction::triggered, this, &MainWindow::connectToAllOpenWorlds);
 
-    m_connectToStartupListAction = connectionMenu->addAction("Connect to Worlds in &Startup List");
+    m_connectToStartupListAction = connectionMenu->addAction("Connect to Worlds &In Startup List");
     m_connectToStartupListAction->setStatusTip(
         "Open and connect to all worlds in the startup list");
     connect(m_connectToStartupListAction, &QAction::triggered, this,


### PR DESCRIPTION
## Summary

Fix Connection menu to match original MUSHclient layout and shortcuts.

## Changes

| Item | Before | After |
|------|--------|-------|
| Quick Connect | Missing | Added (Ctrl+Alt+Shift+K) |
| Connect | Ctrl+G | Ctrl+K |
| Disconnect | Ctrl+Shift+G | Shift+Ctrl+K |
| Connect to All Open Worlds | No shortcut | Ctrl+Alt+K |

## Menu Order (now matches original)

1. Quick Connect (Ctrl+Alt+Shift+K)
2. ---
3. Connect (Ctrl+K)
4. Disconnect (Shift+Ctrl+K)
5. ---
6. Auto Connect
7. Reconnect On Disconnect
8. ---
9. Connect to All Open Worlds (Ctrl+Alt+K)
10. Connect to Worlds In Startup List

## Test plan

- [x] Build succeeds
- [x] Verify menu order in app
- [x] Verify shortcuts work correctly