### PR TITLE
fix: 18 MUSHclient behavioral-parity corrections across subsystems

### DIFF
--- a/src/ui/dialogs/world_properties_dialog.cpp
+++ b/src/ui/dialogs/world_properties_dialog.cpp
@@ -640,7 +640,7 @@ void WorldPropertiesDialog::loadSettings()
     // Connection tab
     m_serverEdit->setText(m_doc->m_server);
     m_portSpin->setValue(m_doc->m_port);
-    m_nameEdit->setText(m_doc->m_mush_name);
+    m_nameEdit->setText(m_doc->m_name);
     m_passwordEdit->setText(m_doc->m_password);
     int connectIdx = m_connectMethodCombo->findData(m_doc->m_connect_now);
     if (connectIdx >= 0)
@@ -789,7 +789,7 @@ void WorldPropertiesDialog::saveSettings()
     // Connection tab
     m_doc->m_server = m_serverEdit->text();
     m_doc->m_port = m_portSpin->value();
-    m_doc->m_mush_name = m_nameEdit->text();
+    m_doc->m_name = m_nameEdit->text();
     m_doc->m_password = m_passwordEdit->text();
     m_doc->m_connect_now = m_connectMethodCombo->currentData().toInt();
     m_doc->m_connect_text = m_connectTextEdit->toPlainText();

--- a/src/ui/dialogs/world_properties_dialog.h
+++ b/src/ui/dialogs/world_properties_dialog.h
@@ -34,6 +34,11 @@ class QGroupBox;
 class WorldPropertiesDialog : public QDialog {
     Q_OBJECT
 
+    // Grants the parity gtest access to private load/save members so it can
+    // verify the "Character name" field binds to m_name (player name), not
+    // m_mush_name (world name). See test_world_properties_dialog_gtest.cpp.
+    friend class WorldPropertiesDialogParityTest;
+
   public:
     /**
      * Constructor

--- a/src/ui/main_window.cpp
+++ b/src/ui/main_window.cpp
@@ -4394,8 +4394,9 @@ void MainWindow::stopSound()
         return;
     }
 
-    // Stop all sounds for this world (buffer 0 = all)
-    worldWidget->document()->StopSound(0);
+    // "Stop sound playing" menu — original OnDisplayStopsoundplaying calls CancelSound,
+    // which fires OnPluginPlaySound (plugins may suppress) before stopping all buffers.
+    worldWidget->document()->CancelSound();
 }
 
 void MainWindow::toggleCommandEcho()

--- a/src/ui/main_window.cpp
+++ b/src/ui/main_window.cpp
@@ -5500,6 +5500,12 @@ void MainWindow::updateStatusIndicators()
         }
         disconnect(m_trackedWorld, &WorldWidget::connectedChanged, this,
                    &MainWindow::onConnectionStateChanged);
+
+        // Fire OnWorldLoseFocus on the world that is losing focus.
+        // Original: CSendView::OnActivateView (sendvw.cpp:972-978).
+        if (WorldDocument* doc = m_trackedWorld->document()) {
+            doc->onWorldLoseFocus();
+        }
     }
 
     // Connect to new world's signals
@@ -5510,6 +5516,12 @@ void MainWindow::updateStatusIndicators()
         }
         connect(worldWidget, &WorldWidget::connectedChanged, this,
                 &MainWindow::onConnectionStateChanged);
+
+        // Fire OnWorldGetFocus on the world that is gaining focus.
+        // Original: CSendView::OnActivateView (sendvw.cpp:941-947).
+        if (WorldDocument* doc = worldWidget->document()) {
+            doc->onWorldGetFocus();
+        }
     }
 
     m_trackedWorld = worldWidget;

--- a/src/ui/main_window.cpp
+++ b/src/ui/main_window.cpp
@@ -2311,6 +2311,18 @@ void MainWindow::closeWorld()
         }
     }
 
+    // Fire the OnWorldClose Lua handler before tearing down the document.
+    // Original: SaveModified() runs the close script once the world is confirmed
+    // closing (doc.cpp:4374-4390).
+    {
+        auto* widget = qobject_cast<WorldWidget*>(sub->widget());
+        if (widget) {
+            if (WorldDocument* doc = widget->document()) {
+                doc->onWorldClose();
+            }
+        }
+    }
+
     sub->close();
 }
 

--- a/src/ui/views/world_widget.cpp
+++ b/src/ui/views/world_widget.cpp
@@ -395,6 +395,10 @@ std::expected<void, QString> WorldWidget::loadFromFile(const QString& filename)
     // This will monitor the script file and reload it based on m_scripting.reload_option
     m_document->setupScriptFileWatcher();
 
+    // Fire OnWorldOpen Lua callback now that the script file has been loaded and its
+    // handler functions are defined. Original: CMUSHclientDoc::OpenSession (doc.cpp:902-913).
+    m_document->onWorldOpen();
+
     // Apply start_paused setting to output view (M192)
     // Original: doc.cpp:789 — pmyView->m_freeze = m_bStartPaused
     applyStartPaused();

--- a/src/world/config_options.cpp
+++ b/src/world/config_options.cpp
@@ -79,8 +79,9 @@ enum { DBG_NONE = 0 };
 // Reload options - see ScriptReloadOption enum in world_document.h
 // eReloadConfirm = 0, eReloadAlways = 1, eReloadNever = 2
 
-// MXP modes
-enum { eNoMXP = 0, eUseMXP = 1, eOnCommandMXP = 2 };
+// MXP modes — numeric values match the original MUSHclient enum (doc.h:350-355)
+// for "use_mxp" world-file / Lua GetOption/SetOption cross-compatibility.
+enum { eOnCommandMXP = 0, eQueryMXP = 1, eUseMXP = 2, eNoMXP = 3 };
 
 // Sound literal
 inline constexpr const char* NOSOUNDLIT = "";

--- a/src/world/connection_manager.cpp
+++ b/src/world/connection_manager.cpp
@@ -134,7 +134,7 @@ void ConnectionManager::onConnect(int errorCode)
 
         // Activate MXP if always-on mode is configured.
         // Original: doc.cpp:6611-6612 — MXP_On() called at connect when m_iUseMXP == eUseMXP
-        if (m_doc.m_iUseMXP == MXPMode::eMXP_On) {
+        if (m_doc.m_iUseMXP == MXPMode::eMXP_Always) {
             m_doc.MXP_On();
         }
 

--- a/src/world/lua_api/lua_common.h
+++ b/src/world/lua_api/lua_common.h
@@ -201,7 +201,7 @@ inline QRgb getColor(lua_State* L, int index, QRgb defaultColor = qRgb(255, 255,
  * - Must start with a letter
  * - Can only contain letters, digits, and underscores
  *
- * @param name Name to validate (will be trimmed)
+ * @param name Name to validate (will be trimmed and lowercased on success)
  * @return eOK (0) if valid, eInvalidObjectLabel (30008) if invalid
  */
 inline qint32 validateObjectName(QString& name)
@@ -226,6 +226,9 @@ inline qint32 validateObjectName(QString& name)
             return eInvalidObjectLabel;
         }
     }
+
+    // Object names are keyed in lower case (matches CheckObjectName::MakeLower)
+    name = name.toLower();
 
     return eOK;
 }

--- a/src/world/lua_api/world_colors.cpp
+++ b/src/world/lua_api/world_colors.cpp
@@ -8,6 +8,7 @@
 #include "../color_utils.h"
 #include "lua_common.h"
 #include <QColorDialog>
+#include <cstdint>
 
 /**
  * ColourNameToRGB - Convert color name to BGR value
@@ -416,7 +417,14 @@ QString RGBColourToName(QRgb bgr)
 int L_ColourNameToRGB(lua_State* L)
 {
     auto [name] = luaArgs<QString>(L);
-    return luaReturn(L, static_cast<lua_Integer>(ColourNameToRGB(name)));
+    // Original (methods_colours.cpp:31-32) returns a signed long -1 on failure,
+    // which Lua sees as -1. QRgb is unsigned 32-bit, so the unknown-name sentinel
+    // 0xFFFFFFFF would otherwise reach Lua as 4294967295 on 64-bit platforms,
+    // breaking plugin `== -1` checks. Sign-extend the 32-bit result: valid BGR
+    // values are 0x00BBGGRR (top byte zero, always positive) and pass through
+    // unchanged, while the 0xFFFFFFFF sentinel becomes -1.
+    const QRgb rgb = ColourNameToRGB(name);
+    return luaReturn(L, static_cast<lua_Integer>(static_cast<std::int32_t>(rgb)));
 }
 
 /**

--- a/src/world/lua_api/world_miniwindow_images.cpp
+++ b/src/world/lua_api/world_miniwindow_images.cpp
@@ -64,28 +64,14 @@ int L_WindowLoadImage(lua_State* L)
         return luaReturnError(L, eNoSuchWindow);
     }
 
-    // Load the image file using Qt
-    qFilename = qFilename.trimmed();
+    // Delegate to MiniWindow::LoadImage, which enforces the original's behavior:
+    // minimum length >= 5, .bmp/.png extension filter, and distinguishes
+    // eFileNotFound from eUnableToLoadImage (original lua_methods.cpp:6067-6077 ->
+    // miniwindow.cpp:1047-1103).
+    qint32 result = win->LoadImage(qImageId, qFilename.trimmed());
 
-    // Empty filename means remove the image
-    if (qFilename.isEmpty()) {
-        // Erase from map (unique_ptr automatically deletes)
-        win->images.erase(qImageId);
-        return luaReturnOK(L);
-    }
-
-    // Load the image as a QImage
-    auto image = std::make_unique<QImage>(qFilename);
-    if (image->isNull()) {
-        lua_pushnumber(L, eFileNotFound);
-        return 1;
-    }
-
-    // Store in miniwindow's image map (replaces old one if it exists; old unique_ptr automatically
-    // deletes)
-    win->images[qImageId] = std::move(image);
-
-    return luaReturnOK(L);
+    lua_pushnumber(L, result);
+    return 1;
 }
 
 /**

--- a/src/world/lua_api/world_plugins.cpp
+++ b/src/world/lua_api/world_plugins.cpp
@@ -676,16 +676,21 @@ int L_ReloadPlugin(lua_State* L)
     // Save plugin filepath before unloading
     QString filepath = plugin->m_strSource;
 
-    // Unload plugin (use actual ID, not input which might be a name)
-    if (!pDoc->UnloadPlugin(plugin->m_strID)) {
+    // Unload plugin (use actual ID, not input which might be a name).
+    // Suppress the list-changed notification: the original ReloadPlugin fires
+    // PluginListChanged exactly once, after the reload completes, so observers
+    // never see the intermediate (plugin-removed) state.
+    if (!pDoc->UnloadPlugin(plugin->m_strID, /*suppressListChanged=*/true)) {
         return luaReturnError(L, eProblemsLoadingPlugin);
     }
 
-    // Reload it
+    // Reload it (also suppressed; we fire the single notification below)
     QString errorMsg;
-    Plugin* newPlugin = pDoc->LoadPlugin(filepath, errorMsg);
+    Plugin* newPlugin = pDoc->LoadPlugin(filepath, errorMsg, /*suppressListChanged=*/true);
 
     if (newPlugin) {
+        // Original fires PluginListChanged once, only on successful reload.
+        pDoc->PluginListChanged();
         lua_pushnumber(L, eOK);
     } else {
         lua_pushnumber(L, ePluginFileNotFound);

--- a/src/world/lua_api/world_session.cpp
+++ b/src/world/lua_api/world_session.cpp
@@ -38,8 +38,11 @@ int L_Execute(lua_State* L)
 
     // ON_PLUGIN_COMMAND is now fired per stacked sub-command inside Execute(),
     // matching original methods_commands.cpp:362 behavior.
-    pDoc->Execute(str, true, false); // allowScriptPrefix=true, addHistory=false
-    lua_pushinteger(L, eOK);
+    // Push Execute()'s long return code so the depth guard (eCommandsNestedTooDeeply)
+    // and world-closed (eWorldClosed) cases reach the Lua caller, matching original
+    // lua_methods.cpp:2269.
+    long result = pDoc->Execute(str, true, false); // allowScriptPrefix=true, addHistory=false
+    lua_pushinteger(L, result);
     return 1;
 }
 

--- a/src/world/lua_api/world_settings.cpp
+++ b/src/world/lua_api/world_settings.cpp
@@ -1682,7 +1682,7 @@ int L_SetOption(lua_State* L)
         // (original: scriptingoptions.cpp:577-583)
         if (pDoc->m_iUseMXP == MXPMode::eMXP_Off && pDoc->m_mxpEngine->m_bMXP) {
             pDoc->MXP_Off(true);
-        } else if (pDoc->m_iUseMXP == MXPMode::eMXP_On && !pDoc->m_mxpEngine->m_bMXP) {
+        } else if (pDoc->m_iUseMXP == MXPMode::eMXP_Always && !pDoc->m_mxpEngine->m_bMXP) {
             // Manual toggle: preserve custom elements/entities defined by the server.
             // Original: mxpOnOff.cpp:133-155 — bManual=true skips clearing custom defs.
             pDoc->MXP_On(true);

--- a/src/world/lua_api/world_settings.cpp
+++ b/src/world/lua_api/world_settings.cpp
@@ -1003,16 +1003,32 @@ int L_GetInfo(lua_State* L)
             break;
 
         case 213: // Output font width
-            lua_pushinteger(L, pDoc->m_FontWidth);
+            // Original returns m_FontWidth (= tm.tmAveCharWidth, doc.cpp:3258).
+            // Compute on-the-fly from the same font OutputView renders with, since
+            // m_FontWidth is never updated after construction.
+            {
+                QFont outputFont =
+                    createScaledFont(pDoc->m_output.font_name, pDoc->m_output.font_height);
+                lua_pushinteger(L, QFontMetrics(outputFont).averageCharWidth());
+            }
             break;
 
         case 214: // Input font height
-            // Based on: methods_info.cpp
-            lua_pushinteger(L, pDoc->m_InputFontHeight);
+            // Original returns m_InputFontHeight (= tm.tmHeight, doc.cpp:3323).
+            {
+                QFont inputFont =
+                    createScaledFont(pDoc->m_input.font_name, pDoc->m_input.font_height);
+                lua_pushinteger(L, QFontMetrics(inputFont).height());
+            }
             break;
 
         case 215: // Input font width
-            lua_pushinteger(L, pDoc->m_InputFontWidth);
+            // Original returns m_InputFontWidth (= tm.tmAveCharWidth, doc.cpp:3324).
+            {
+                QFont inputFont =
+                    createScaledFont(pDoc->m_input.font_name, pDoc->m_input.font_height);
+                lua_pushinteger(L, QFontMetrics(inputFont).averageCharWidth());
+            }
             break;
 
         case 216: // Bytes received
@@ -1158,7 +1174,13 @@ int L_GetInfo(lua_State* L)
             break;
 
         case 240: // Average character width
-            lua_pushinteger(L, pDoc->m_FontWidth);
+            // Original returns m_FontWidth (= tm.tmAveCharWidth, doc.cpp:3258).
+            // Compute on-the-fly to match GetInfo(213); m_FontWidth is never updated.
+            {
+                QFont outputFont =
+                    createScaledFont(pDoc->m_output.font_name, pDoc->m_output.font_height);
+                lua_pushinteger(L, QFontMetrics(outputFont).averageCharWidth());
+            }
             break;
 
         case 241: // Character height (rendered pixel height, same as GetInfo(212))

--- a/src/world/miniwindow.cpp
+++ b/src/world/miniwindow.cpp
@@ -139,6 +139,46 @@ static QPen createWindowsPen(const QColor& color, int width, int penStyle)
     return pen;
 }
 
+// CreateImage() stores monochrome (1-bpp) brush patterns as pure white pixels for
+// set bits and pure black pixels for clear bits. The original GDI ImageOp paints
+// such patterns with SetTextColor(BrushColour) for the 1-bits and
+// SetBkColor(PenColour) for the 0-bits (reference: miniwindow.cpp:1905-1907).
+// Returns true if every pixel is pure black or pure white, i.e. the image is a
+// monochrome pattern that must be colour-remapped before being used as a brush.
+static bool isMonochromePattern(const QImage& img)
+{
+    for (int y = 0; y < img.height(); ++y) {
+        for (int x = 0; x < img.width(); ++x) {
+            const QRgb px = img.pixel(x, y);
+            const int r = qRed(px);
+            const int g = qGreen(px);
+            const int b = qBlue(px);
+            const bool isWhite = (r == 255 && g == 255 && b == 255);
+            const bool isBlack = (r == 0 && g == 0 && b == 0);
+            if (!isWhite && !isBlack)
+                return false;
+        }
+    }
+    return true;
+}
+
+// Build a colour-remapped copy of a monochrome pattern: white (set bits) becomes
+// the brush colour (GDI text colour), black (clear bits) becomes the pen colour
+// (GDI background colour). Matches the original ImageOp colour semantics.
+static QImage remapMonochromePattern(const QImage& src, QRgb penColor, QRgb brushColor)
+{
+    const QColor foreground = bgrToColor(brushColor); // 1-bits -> text colour
+    const QColor background = bgrToColor(penColor);   // 0-bits -> background colour
+    QImage out(src.size(), QImage::Format_ARGB32);
+    for (int y = 0; y < src.height(); ++y) {
+        for (int x = 0; x < src.width(); ++x) {
+            const bool set = (qRed(src.pixel(x, y)) == 255);
+            out.setPixel(x, y, (set ? foreground : background).rgb());
+        }
+    }
+    return out;
+}
+
 /**
  * @brief Constructor
  * @param doc Parent WorldDocument
@@ -518,6 +558,12 @@ qint32 MiniWindow::CircleOp(qint16 action, qint32 left, qint32 top, qint32 right
     if (!validatePenStyle(penStyle, penWidth))
         return ePenStyleNotValid;
 
+    // Validate brush style: original ValidateBrushStyle accepts only 0-12
+    // (0=solid, 1=null, 2-12=hatched/pattern). Anything else is rejected.
+    // (reference: miniwindow.cpp:506,541-542 — default branch returns eBrushStyleNotValid)
+    if (brushStyle < 0 || brushStyle > 12)
+        return eBrushStyleNotValid;
+
     // Handle special meaning for right/bottom (from miniwindow.cpp)
     // - right <= 0 means offset from right edge (0 = right edge, -1 = 1px from right)
     // - bottom <= 0 means offset from bottom edge (0 = bottom edge, -1 = 1px from bottom)
@@ -749,13 +795,21 @@ qint32 MiniWindow::Arc(qint32 left, qint32 top, qint32 right, qint32 bottom, qin
     qreal cx = (left + right) / 2.0;
     qreal cy = (top + bottom) / 2.0;
 
+    // Semi-radii of the bounding ellipse. GDI Arc() projects the (x1,y1)/(x2,y2)
+    // rays onto the ellipse to find the arc endpoints, so the point coordinates
+    // must be scaled by the ellipse aspect ratio before converting to an angle.
+    // A point on the ellipse is (cx + a*cos t, cy - b*sin t), giving
+    //   t = atan2(-(y-cy)/b, (x-cx)/a) = atan2(-a*(y-cy), b*(x-cx)).
+    qreal a = (right - left) / 2.0;
+    qreal b = (bottom - top) / 2.0;
+
     // Convert GDI point-based arc to Qt angle-based arc.
     // GDI Arc draws counterclockwise (mathematically) from start to end point.
     // Qt drawArc uses angles in 1/16 degree, counterclockwise from 3 o'clock.
     // In screen coords (Y-down), atan2 gives clockwise angles from east,
     // so negate Y to convert to Qt's counterclockwise convention.
-    qreal startAngle = qAtan2(-(y1 - cy), x1 - cx) * 180.0 / M_PI;
-    qreal endAngle = qAtan2(-(y2 - cy), x2 - cx) * 180.0 / M_PI;
+    qreal startAngle = qAtan2(-a * (y1 - cy), b * (x1 - cx)) * 180.0 / M_PI;
+    qreal endAngle = qAtan2(-a * (y2 - cy), b * (x2 - cx)) * 180.0 / M_PI;
 
     // GDI draws counterclockwise from start to end (positive direction in Qt)
     qreal spanAngle = endAngle - startAngle;
@@ -2099,8 +2153,18 @@ qint32 MiniWindow::ImageOp(qint16 action, qint32 left, qint32 top, qint32 right,
     QPen pen = createWindowsPen(bgrToColor(penColor), penWidth, penStyle);
     painter.setPen(pen);
 
-    // Setup brush with image pattern
-    QBrush brush(*brushImg);
+    // Setup brush with image pattern.
+    // For monochrome patterns (created via CreateImage as white/black), GDI remaps
+    // 1-bits to the brush colour and 0-bits to the pen colour. Apply the same
+    // remapping so brushColor is honoured (reference: miniwindow.cpp:1905-1907).
+    QImage remappedPattern;
+    const QImage* patternToUse = brushImg;
+    if (isMonochromePattern(*brushImg)) {
+        remappedPattern = remapMonochromePattern(*brushImg, penColor, brushColor);
+        patternToUse = &remappedPattern;
+    }
+
+    QBrush brush(*patternToUse);
     brush.setStyle(Qt::TexturePattern);
     painter.setBrush(brush);
 

--- a/src/world/miniwindow.cpp
+++ b/src/world/miniwindow.cpp
@@ -6,6 +6,7 @@
 #include <QColor>
 #include <QDateTime>
 #include <QDebug>
+#include <QFileInfo>
 #include <QFontMetrics>
 #include <QImage>
 #include <QPainter>
@@ -1377,7 +1378,9 @@ qint32 MiniWindow::LoadImage(const QString& imageId, const QString& filepath)
     // Load image using Qt (QImage is platform-independent)
     auto img = std::make_unique<QImage>(filepath);
     if (img->isNull()) {
-        return eFileNotFound;
+        // Original (miniwindow.cpp:1097-1100, Utilities.cpp:2976-2977) distinguishes a missing
+        // file (eFileNotFound) from a file that exists but cannot be decoded (eUnableToLoadImage).
+        return QFileInfo::exists(filepath) ? eUnableToLoadImage : eFileNotFound;
     }
 
     // Insert new image (replaces old one if it exists; old unique_ptr automatically deletes)

--- a/src/world/mxp_engine.cpp
+++ b/src/world/mxp_engine.cpp
@@ -23,6 +23,24 @@
 #include <QRegularExpression>
 #include <memory>
 
+namespace {
+
+// Validate an MXP name: must start with a letter, then letters/digits/_/-/. only.
+// Mirrors IsValidName in the original (mxp/mxputils.cpp:402).
+bool mxpIsValidName(const QString& str)
+{
+    if (str.isEmpty() || !str.at(0).isLetter())
+        return false;
+    for (const QChar c : str) {
+        if (c.isLetterOrNumber() || c == '_' || c == '-' || c == '.')
+            continue;
+        return false;
+    }
+    return true;
+}
+
+} // namespace
+
 // ========================================================================
 // Constructor / Destructor
 // ========================================================================
@@ -1251,8 +1269,10 @@ void MXPEngine::MXP_StartTag(const QString& tagString)
 
     tagName = tagName.toLower(); // Case-insensitive
 
-    // Check if current mode is secure
-    bool bSecure = (m_iMXP_mode == eMXP_secure || m_iMXP_mode == eMXP_perm_secure);
+    // Capture secure mode BEFORE restoring (original: mxpStart.cpp:31 — bool bSecure =
+    // MXP_Secure() which is true for eMXP_secure, eMXP_secure_once, and eMXP_perm_secure;
+    // MXP_Restore_Mode() then cancels secure_once afterward on line 34).
+    bool bSecure = MXP_Secure();
 
     // Restore mode (cancel secure-once) — original: MXP_Restore_Mode in mxpMode.cpp
     if (m_iMXP_mode == eMXP_secure_once) {
@@ -1405,8 +1425,10 @@ void MXPEngine::MXP_StartTag(const QString& tagString)
  */
 void MXPEngine::MXP_EndTag(const QString& tagString)
 {
-    // Check if current mode is secure
-    bool bSecure = (m_iMXP_mode == eMXP_secure || m_iMXP_mode == eMXP_perm_secure);
+    // Capture secure mode BEFORE restoring (original: mxpEnd.cpp:24 — bool bSecure =
+    // MXP_Secure() which is true for eMXP_secure, eMXP_secure_once, and eMXP_perm_secure;
+    // MXP_Restore_Mode() then cancels secure_once afterward on line 26).
+    bool bSecure = MXP_Secure();
 
     // Restore mode (cancel secure-once) — original: MXP_Restore_Mode in mxpMode.cpp
     if (m_iMXP_mode == eMXP_secure_once) {
@@ -2220,9 +2242,11 @@ void MXPEngine::MXP_ExecuteAction(AtomicElement* elem, MXPArgumentList& args)
         // ========== SERVER COMMANDS ==========
         case MXP_ACTION_VERSION: {
             // Send client version to server (original: mxpOpenAtomic.cpp:288-304)
-            // Format: ESC[1z<VERSION MXP="0.4" CLIENT=Mushkin VERSION="x.y.z" REGISTERED=YES>\r\n
+            // Format: ESC[1z<VERSION MXP="0.5" CLIENT=Mushkin VERSION="x.y.z" REGISTERED=YES>\r\n
+            // MXP protocol version is 0.5 (original: mxpOpenAtomic.cpp:20 #define MXP_VERSION
+            // "0.5")
             QString versionResponse =
-                QString("\x1B[1z<VERSION MXP=\"0.4\" CLIENT=Mushkin VERSION=\"%1\" "
+                QString("\x1B[1z<VERSION MXP=\"0.5\" CLIENT=Mushkin VERSION=\"%1\" "
                         "REGISTERED=YES>\r\n")
                     .arg(QCoreApplication::applicationVersion());
             QByteArray data = versionResponse.toUtf8();
@@ -2396,12 +2420,19 @@ void MXPEngine::MXP_ExecuteAction(AtomicElement* elem, MXPArgumentList& args)
                     argValue = argValue.toLower();
 
                     const QStringList parts = argValue.split('.', Qt::SkipEmptyParts);
+                    // Original (mxpOpenAtomic.cpp:368-374): >2 components is an invalid
+                    // argument — MXP_error then plain return, so NO <SUPPORTS> reply is sent.
                     if (parts.isEmpty() || parts.size() > 2) {
                         qCWarning(lcMXP) << "Invalid <support> argument:" << argValue;
-                        continue;
+                        return;
                     }
 
                     const QString tagName = parts[0];
+                    // Original (mxpOpenAtomic.cpp:380-386): invalid tag name -> return (no reply).
+                    if (!mxpIsValidName(tagName)) {
+                        qCWarning(lcMXP) << "Invalid <support> argument:" << tagName;
+                        return;
+                    }
                     auto it = m_atomicElementMap.find(tagName);
                     if (it == m_atomicElementMap.end() || (it->second->iFlags & TAG_NOT_IMP)) {
                         // Tag unknown or not supported
@@ -2424,6 +2455,12 @@ void MXPEngine::MXP_ExecuteAction(AtomicElement* elem, MXPArgumentList& args)
                             supports += QString("+%1.%2 ").arg(tagName, attr.trimmed());
                         }
                     } else {
+                        // Original (mxpOpenAtomic.cpp:428-434): invalid subtag name -> return
+                        // (no reply).
+                        if (!mxpIsValidName(subtag)) {
+                            qCWarning(lcMXP) << "Invalid <support> argument:" << subtag;
+                            return;
+                        }
                         // Specific sub-attribute lookup (original: 437-449)
                         bool found = false;
                         for (const QString& attr : subAttrs) {

--- a/src/world/world_document.cpp
+++ b/src/world/world_document.cpp
@@ -1390,7 +1390,7 @@ bool WorldDocument::checkConnected()
     return false;
 }
 
-void WorldDocument::Execute(const QString& command, bool allowScriptPrefix, bool addHistory,
+long WorldDocument::Execute(const QString& command, bool allowScriptPrefix, bool addHistory,
                             const QString& originalCommand)
 {
     // Recursion depth guard — prevents infinite alias loops from crashing.
@@ -1398,7 +1398,8 @@ void WorldDocument::Execute(const QString& command, bool allowScriptPrefix, bool
     constexpr int MAX_EXECUTION_DEPTH = 100;
     if (++m_iExecutionDepth > MAX_EXECUTION_DEPTH) {
         --m_iExecutionDepth;
-        return; // Original returns eCommandsNestedTooDeeply to Lua caller
+        // Original (methods_commands.cpp:265) returns eCommandsNestedTooDeeply to Lua caller.
+        return eCommandsNestedTooDeeply;
     }
     // RAII guard to decrement depth on any return path
     struct DepthGuard {
@@ -1438,7 +1439,7 @@ void WorldDocument::Execute(const QString& command, bool allowScriptPrefix, bool
             // Warn that scripting is not active
             note("Scripting is not active yet, or script file had a parse error.");
         }
-        return; // Don't process further (script handled)
+        return eOK; // Don't process further (script handled)
     }
 
     // ========== Speed Walking ==========
@@ -1450,7 +1451,7 @@ void WorldDocument::Execute(const QString& command, bool allowScriptPrefix, bool
     if (m_speedwalk.enabled && strFixedCommand.startsWith(m_speedwalk.prefix)) {
         // Check connection before processing speedwalk (original: evaluate.cpp:52-53)
         if (connectPhase() != eConnectConnectedToMud)
-            return;
+            return eWorldClosed;
         // Remove prefix and evaluate speedwalk
         QString speedwalkInput = strFixedCommand.mid(m_speedwalk.prefix.length());
         QString expandedSpeedwalk = speedwalk::evaluate(speedwalkInput, m_speedwalk.filler);
@@ -1461,13 +1462,13 @@ void WorldDocument::Execute(const QString& command, bool allowScriptPrefix, bool
                 // Show error message to user (skip the '*')
                 qCDebug(lcWorld) << "Speedwalk error:" << expandedSpeedwalk.mid(1);
                 note(expandedSpeedwalk.mid(1)); // Display error in output window
-                return;
+                return eOK;
             }
 
             // Send expanded speedwalk commands via SendMsg with queue=true
             SendMsg(expandedSpeedwalk, m_display_my_input, true, m_logging.log_input);
         }
-        return; // Don't process further (speedwalk handled)
+        return eOK; // Don't process further (speedwalk handled)
     }
 
     // ========== Command Stacking ==========
@@ -1555,6 +1556,9 @@ void WorldDocument::Execute(const QString& command, bool allowScriptPrefix, bool
             addToCommandHistory(originalCommand.isEmpty() ? str : originalCommand);
         }
     }
+
+    // All commands processed successfully (original: methods_commands.cpp:398).
+    return eOK;
 }
 
 // NOTE: GetCommandQueue(), Queue(), DiscardQueue() implementation moved to ConnectionManager.

--- a/src/world/world_document.cpp
+++ b/src/world/world_document.cpp
@@ -2685,6 +2685,48 @@ void WorldDocument::onWorldOpen()
 }
 
 /**
+ * onWorldClose — call the Lua OnWorldClose handler if registered.
+ *
+ * Original: CMUSHclientDoc::SaveModified() (doc.cpp:4374-4390). Fired once when
+ * the world is closing, before the document is torn down, so a script can run
+ * cleanup. The handler name is the configurable on_world_close setting
+ * (m_strWorldClose in the original); when unset, no handler fires.
+ */
+void WorldDocument::onWorldClose()
+{
+    if (!m_ScriptEngine) {
+        return;
+    }
+
+    const QString handlerName = m_scripting.on_world_close;
+    if (handlerName.isEmpty()) {
+        return;
+    }
+
+    if (m_dispidWorldClose == 0) {
+        m_dispidWorldClose = m_ScriptEngine->getLuaDispid(handlerName);
+    }
+
+    if (m_dispidWorldClose == DISPID_UNKNOWN) {
+        return;
+    }
+
+    QList<double> nparams;
+    QList<QString> sparams;
+    qint32 invocation_count = 0;
+    bool result = false;
+
+    bool error = m_ScriptEngine->executeLua(m_dispidWorldClose, handlerName,
+                                            ActionSource::eWorldAction, "world", "world close",
+                                            nparams, sparams, invocation_count, &result);
+    if (error) {
+        qCDebug(lcWorld) << "Error calling OnWorldClose callback";
+    } else {
+        qCDebug(lcWorld) << "OnWorldClose callback executed successfully";
+    }
+}
+
+/**
  * onWorldGetFocus — call the Lua OnWorldGetFocus handler if registered.
  *
  * Original: CSendView::OnActivateView() (sendvw.cpp:941-947), fired when the world's

--- a/src/world/world_document.cpp
+++ b/src/world/world_document.cpp
@@ -2646,6 +2646,111 @@ void WorldDocument::loadScriptFile()
 }
 
 /**
+ * onWorldOpen — call the Lua OnWorldOpen handler if registered.
+ *
+ * Original: CMUSHclientDoc::OpenSession() (doc.cpp:902-913). Fired once after the
+ * world's script file has been loaded so the handler function is defined.
+ */
+void WorldDocument::onWorldOpen()
+{
+    if (!m_ScriptEngine) {
+        return;
+    }
+
+    if (m_dispidWorldOpen == 0) {
+        m_dispidWorldOpen = m_ScriptEngine->getLuaDispid("OnWorldOpen");
+    }
+
+    if (m_dispidWorldOpen == DISPID_UNKNOWN) {
+        return;
+    }
+
+    QList<double> nparams;
+    QList<QString> sparams;
+    qint32 invocation_count = 0;
+    bool result = false;
+
+    bool error = m_ScriptEngine->executeLua(m_dispidWorldOpen, "OnWorldOpen",
+                                            ActionSource::eWorldAction, "world", "world open",
+                                            nparams, sparams, invocation_count, &result);
+    if (error) {
+        qCDebug(lcWorld) << "Error calling OnWorldOpen callback";
+    } else {
+        qCDebug(lcWorld) << "OnWorldOpen callback executed successfully";
+    }
+}
+
+/**
+ * onWorldGetFocus — call the Lua OnWorldGetFocus handler if registered.
+ *
+ * Original: CSendView::OnActivateView() (sendvw.cpp:941-947), fired when the world's
+ * command view gains focus.
+ */
+void WorldDocument::onWorldGetFocus()
+{
+    if (!m_ScriptEngine) {
+        return;
+    }
+
+    if (m_dispidWorldGetFocus == 0) {
+        m_dispidWorldGetFocus = m_ScriptEngine->getLuaDispid("OnWorldGetFocus");
+    }
+
+    if (m_dispidWorldGetFocus == DISPID_UNKNOWN) {
+        return;
+    }
+
+    QList<double> nparams;
+    QList<QString> sparams;
+    qint32 invocation_count = 0;
+    bool result = false;
+
+    bool error = m_ScriptEngine->executeLua(m_dispidWorldGetFocus, "OnWorldGetFocus",
+                                            ActionSource::eWorldAction, "world", "world get focus",
+                                            nparams, sparams, invocation_count, &result);
+    if (error) {
+        qCDebug(lcWorld) << "Error calling OnWorldGetFocus callback";
+    } else {
+        qCDebug(lcWorld) << "OnWorldGetFocus callback executed successfully";
+    }
+}
+
+/**
+ * onWorldLoseFocus — call the Lua OnWorldLoseFocus handler if registered.
+ *
+ * Original: CSendView::OnActivateView() (sendvw.cpp:972-978), fired when the world's
+ * command view loses focus.
+ */
+void WorldDocument::onWorldLoseFocus()
+{
+    if (!m_ScriptEngine) {
+        return;
+    }
+
+    if (m_dispidWorldLoseFocus == 0) {
+        m_dispidWorldLoseFocus = m_ScriptEngine->getLuaDispid("OnWorldLoseFocus");
+    }
+
+    if (m_dispidWorldLoseFocus == DISPID_UNKNOWN) {
+        return;
+    }
+
+    QList<double> nparams;
+    QList<QString> sparams;
+    qint32 invocation_count = 0;
+    bool result = false;
+
+    bool error = m_ScriptEngine->executeLua(m_dispidWorldLoseFocus, "OnWorldLoseFocus",
+                                            ActionSource::eWorldAction, "world", "world lose focus",
+                                            nparams, sparams, invocation_count, &result);
+    if (error) {
+        qCDebug(lcWorld) << "Error calling OnWorldLoseFocus callback";
+    } else {
+        qCDebug(lcWorld) << "OnWorldLoseFocus callback executed successfully";
+    }
+}
+
+/**
  * setupScriptFileWatcher - Set up file watcher for script file changes
  *
  * Creates or updates the QFileSystemWatcher to monitor the script file.

--- a/src/world/world_document.h
+++ b/src/world/world_document.h
@@ -1126,7 +1126,8 @@ class WorldDocument : public QObject, public IWorldContext {
     bool m_bPluginProcessingCommand;
     bool m_bPluginProcessingSend;
     bool m_bPluginProcessingSent;
-    bool m_bInPlaySoundFilePlugin = false; // Recursion guard for OnPluginPlaySound
+    bool m_bInPlaySoundFilePlugin = false; // Recursion guard for OnPluginPlaySound (PlaySoundFile)
+    bool m_bInCancelSoundFilePlugin = false; // Recursion guard for OnPluginPlaySound (CancelSound)
     QString m_strLastCommandSent;
     qint32 m_iLastCommandCount;
     qint32 m_iExecutionDepth;
@@ -1895,6 +1896,7 @@ class WorldDocument : public QObject, public IWorldContext {
     // callers in world_trigger_execution.cpp, telnet_parser.cpp, and Lua API bindings.
     qint32 PlaySound(qint16 buffer, const QString& filename, bool loop, double volume, double pan);
     qint32 StopSound(qint16 buffer);
+    void CancelSound();
     bool PlaySoundFile(const QString& filename);
     qint32 GetSoundStatus(qint16 buffer);
     void PlayMSPSound(const QString& filename, const QString& url, bool loop, double volume,

--- a/src/world/world_document.h
+++ b/src/world/world_document.h
@@ -150,8 +150,16 @@ enum {
     eConnectTypeMax // must be last
 };
 
-// MXP usage values
-enum class MXPMode : quint16 { eMXP_Off, eMXP_Query, eMXP_On };
+// MXP usage values (see m_iUseMXP). Numeric values MUST match the original
+// MUSHclient enum in doc.h (eOnCommandMXP=0, eQueryMXP=1, eUseMXP=2, eNoMXP=3)
+// so that the "use_mxp" world-file value and Lua GetOption/SetOption stay
+// cross-compatible.
+enum class MXPMode : quint16 {
+    eMXP_On = 0,     // eOnCommandMXP: turn on after IAC SB MXP IAC SE (default)
+    eMXP_Query = 1,  // eQueryMXP: turn on after option query
+    eMXP_Always = 2, // eUseMXP: always on (activated at connect)
+    eMXP_Off = 3,    // eNoMXP: always off
+};
 
 // Connection phase values (doc.h)
 // These are now inline constexpr aliases to connection_manager.h constants.

--- a/src/world/world_document.h
+++ b/src/world/world_document.h
@@ -1593,6 +1593,7 @@ class WorldDocument : public QObject, public IWorldContext {
     // Original: OpenSession() fires OnWorldOpen (doc.cpp:902-913);
     // CSendView::OnActivateView fires OnWorldGetFocus/OnWorldLoseFocus (sendvw.cpp:941-978).
     void onWorldOpen();      // Fire OnWorldOpen Lua handler after world load
+    void onWorldClose();     // Fire OnWorldClose Lua handler before world close
     void onWorldGetFocus();  // Fire OnWorldGetFocus Lua handler when world gains focus
     void onWorldLoseFocus(); // Fire OnWorldLoseFocus Lua handler when world loses focus
 

--- a/src/world/world_document.h
+++ b/src/world/world_document.h
@@ -1843,8 +1843,9 @@ class WorldDocument : public QObject, public IWorldContext {
     Plugin* FindPluginByName(const QString& pluginName);   // Find plugin by name
     Plugin* FindPluginByFilePath(const QString& filepath); // Find plugin by source file path
     Plugin* LoadPlugin(const QString& filepath, QString& errorMsg,
-                       bool suppressListChanged = false);     // Load plugin from XML file
-    bool UnloadPlugin(const QString& pluginID);               // Unload and delete plugin
+                       bool suppressListChanged = false); // Load plugin from XML file
+    bool UnloadPlugin(const QString& pluginID,
+                      bool suppressListChanged = false);      // Unload and delete plugin
     bool EnablePlugin(const QString& pluginID, bool enabled); // Enable/disable plugin
     void PluginListChanged();                                 // Notify plugins that list changed
     Plugin* getPlugin(const QString& pluginID); // Get plugin by ID (alias for FindPluginByID)

--- a/src/world/world_document.h
+++ b/src/world/world_document.h
@@ -1455,6 +1455,10 @@ class WorldDocument : public QObject, public IWorldContext {
     {
         m_mxpEngine->CleanupMXP();
     }
+    void MXP_CloseOpenTags(bool closeAll = false)
+    {
+        m_mxpEngine->MXP_CloseOpenTags(closeAll);
+    }
     bool MXP_Open() const
     {
         return m_mxpEngine->MXP_Open();

--- a/src/world/world_document.h
+++ b/src/world/world_document.h
@@ -1817,7 +1817,9 @@ class WorldDocument : public QObject, public IWorldContext {
                        ProgressCallback progressCallback = nullptr);
 
     // ========== Command Stacking ==========
-    void
+    // Returns an error code (eOK, eCommandsNestedTooDeeply, ...) matching the original
+    // CMUSHclientDoc::Execute long return value, which world.Execute pushes to Lua.
+    long
     Execute(const QString& command, bool allowScriptPrefix = true, bool addHistory = true,
             const QString& originalCommand = QString()); // Process command with stacking support
     bool checkConnected(); // Prompt to reconnect if disconnected (original: doc.cpp:5158)

--- a/src/world/world_document.h
+++ b/src/world/world_document.h
@@ -1584,6 +1584,13 @@ class WorldDocument : public QObject, public IWorldContext {
     // NOTE: onWorldConnect() and onWorldDisconnect() moved to ConnectionManager (private).
     // They are called from ConnectionManager::onConnect() and onConnectionDisconnect().
 
+    // ========== World-level Lua callbacks ==========
+    // Original: OpenSession() fires OnWorldOpen (doc.cpp:902-913);
+    // CSendView::OnActivateView fires OnWorldGetFocus/OnWorldLoseFocus (sendvw.cpp:941-978).
+    void onWorldOpen();      // Fire OnWorldOpen Lua handler after world load
+    void onWorldGetFocus();  // Fire OnWorldGetFocus Lua handler when world gains focus
+    void onWorldLoseFocus(); // Fire OnWorldLoseFocus Lua handler when world loses focus
+
     // ========== Trigger and Alias Management ==========
     // Forwarding wrappers — implementation delegates to m_automationRegistry.
     [[nodiscard]] std::expected<void, WorldError> addTrigger(const QString& name,

--- a/src/world/world_document.h
+++ b/src/world/world_document.h
@@ -811,7 +811,7 @@ class WorldDocument : public QObject, public IWorldContext {
         // Logging flags
         bool log_html = false;          // convert HTML sequences?
         bool log_input = false;         // log player input?
-        bool log_output = false;        // log MUD output?
+        bool log_output = true;         // log MUD output? (original default: true)
         bool log_notes = false;         // log notes?
         bool log_in_colour = false;     // HTML logging in colour?
         bool log_raw = false;           // log raw input from MUD?

--- a/src/world/world_document_plugins.cpp
+++ b/src/world/world_document_plugins.cpp
@@ -626,7 +626,7 @@ bool WorldDocument::EnablePlugin(const QString& pluginID, bool enabled)
  * @param pluginID Plugin GUID
  * @return true on success, false if plugin not found or currently executing
  */
-bool WorldDocument::UnloadPlugin(const QString& pluginID)
+bool WorldDocument::UnloadPlugin(const QString& pluginID, bool suppressListChanged)
 {
     Plugin* plugin = FindPluginByID(pluginID);
     if (!plugin) {
@@ -650,8 +650,10 @@ bool WorldDocument::UnloadPlugin(const QString& pluginID)
         m_PluginList.erase(it); // OnPluginClose called in destructor
     }
 
-    // Notify other plugins
-    PluginListChanged();
+    // Notify other plugins (unless caller will batch the notification, e.g. ReloadPlugin)
+    if (!suppressListChanged) {
+        PluginListChanged();
+    }
 
     return true;
 }

--- a/src/world/world_document_plugins.cpp
+++ b/src/world/world_document_plugins.cpp
@@ -699,6 +699,8 @@ void WorldDocument::SendToAllPluginCallbacks(const QString& callbackName)
 {
     Plugin* savedPlugin = m_CurrentPlugin;
 
+    m_bNotesNotWantedNow = true; // batch up Note/Tell calls
+
     for (const auto& plugin : m_PluginList) {
         if (!plugin || !plugin->m_bEnabled) {
             continue;
@@ -709,6 +711,7 @@ void WorldDocument::SendToAllPluginCallbacks(const QString& callbackName)
     }
 
     m_CurrentPlugin = savedPlugin;
+    m_bNotesNotWantedNow = false;
 }
 
 /**
@@ -730,6 +733,8 @@ bool WorldDocument::SendToAllPluginCallbacks(const QString& callbackName, const 
     Plugin* savedPlugin = m_CurrentPlugin;
     bool result = true;
 
+    m_bNotesNotWantedNow = true; // batch up Note/Tell calls
+
     for (const auto& plugin : m_PluginList) {
         if (!plugin || !plugin->m_bEnabled) {
             continue;
@@ -747,6 +752,7 @@ bool WorldDocument::SendToAllPluginCallbacks(const QString& callbackName, const 
     }
 
     m_CurrentPlugin = savedPlugin;
+    m_bNotesNotWantedNow = false;
     return result;
 }
 
@@ -796,6 +802,8 @@ bool WorldDocument::SendToAllPluginCallbacks(const QString& callbackName, qint32
     Plugin* savedPlugin = m_CurrentPlugin;
     bool result = false;
 
+    m_bNotesNotWantedNow = true; // batch up Note/Tell calls
+
     for (const auto& plugin : m_PluginList) {
         if (!plugin || !plugin->m_bEnabled) {
             continue;
@@ -813,6 +821,7 @@ bool WorldDocument::SendToAllPluginCallbacks(const QString& callbackName, qint32
     }
 
     m_CurrentPlugin = savedPlugin;
+    m_bNotesNotWantedNow = false;
     return result;
 }
 
@@ -835,6 +844,8 @@ bool WorldDocument::SendToAllPluginCallbacks(const QString& callbackName, qint32
     Plugin* savedPlugin = m_CurrentPlugin;
     bool result = true;
 
+    m_bNotesNotWantedNow = true; // batch up Note/Tell calls
+
     for (const auto& plugin : m_PluginList) {
         if (!plugin || !plugin->m_bEnabled) {
             continue;
@@ -849,6 +860,7 @@ bool WorldDocument::SendToAllPluginCallbacks(const QString& callbackName, qint32
     }
 
     m_CurrentPlugin = savedPlugin;
+    m_bNotesNotWantedNow = false;
     return result;
 }
 

--- a/src/world/world_protocol.cpp
+++ b/src/world/world_protocol.cpp
@@ -158,6 +158,16 @@ void WorldDocument::ProcessIncomingByte(unsigned char c)
                 m_mxpEngine->m_strMXPstring.clear();
                 phase = Phase::HAVE_MXP_ENTITY;
             } else if (c == '\n') {
+                // Original: doc.cpp:2071-2076 — at end of line, close any open MXP
+                // tags and revert to the default line-mode. flags is always 0 on the
+                // socket path (no NOTE_OR_COMMAND), so the original guard reduces to
+                // MXP active and not in Pueblo mode.
+                if (isMXPActive() && !isPuebloActive()) {
+                    if (!MXP_Open()) {
+                        MXP_CloseOpenTags(); // close all open tags
+                    }
+                    MXP_mode_change(-1); // switch to default mode
+                }
                 StartNewLine(true, 0);
             } else if (c == '\r') {
                 // Carriage return without LF - ignore
@@ -286,6 +296,13 @@ void WorldDocument::SendPacket(std::span<const unsigned char> data)
     }
 
     m_connectionManager->m_iOutputPacketCount++;
+
+    // Original: doc.cpp:5593-5594 — dump outgoing packet hex when packet debug is on.
+    if (m_bDebugIncomingPackets) {
+        debugPacketData("Sent ", reinterpret_cast<const char*>(data.data()),
+                        static_cast<int>(data.size()), m_connectionManager->m_iOutputPacketCount);
+    }
+
     m_connectionManager->m_nBytesOut += static_cast<qint64>(data.size());
 
     // Ignore send errors — callers don't check return value for protocol packets

--- a/src/world/world_serialization.cpp
+++ b/src/world/world_serialization.cpp
@@ -375,12 +375,10 @@ void WorldDocument::loadTriggersFromXml(QXmlStreamReader& xml, Plugin* plugin)
 
             // Add to plugin or world collections based on context
             if (plugin) {
-                // Add to plugin's collections
-                trigger->internal_name =
-                    trigger->label.isEmpty()
-                        ? QString("trigger_%1_%2").arg(triggerCount).arg(qHash(trigger->trigger))
-                        : trigger->label;
-
+                // Add to plugin's collections. internal_name was already computed
+                // above (lowercased for labeled triggers, matching original
+                // xml_load_world.cpp:1314) — do not recompute it here, which would
+                // re-introduce the original-case label and undo the H65 fix.
                 QString triggerName = trigger->internal_name;
 
                 // Skip name-based duplicates

--- a/src/world/world_sound.cpp
+++ b/src/world/world_sound.cpp
@@ -21,15 +21,28 @@ qint32 WorldDocument::PlaySound(qint16 buffer, const QString& filename, bool loo
 
 qint32 WorldDocument::StopSound(qint16 buffer)
 {
-    // When stopping all sounds (buffer=0), fire OnPluginPlaySound with empty string
-    // to let plugins know sounds are being cancelled.
-    // Original: CancelSound (doc.cpp:7137-7158)
-    if (buffer == 0 && !m_bInPlaySoundFilePlugin) {
-        m_bInPlaySoundFilePlugin = true;
-        SendToFirstPluginCallbacks(ON_PLUGIN_PLAY_SOUND, QString());
-        m_bInPlaySoundFilePlugin = false;
-    }
+    // Pure DirectSound buffer stop — no plugin callback.
+    // Original: CMUSHclientDoc::StopSound (methods_sounds.cpp:361-402) fires no callback;
+    // the OnPluginPlaySound notification belongs to CancelSound, not StopSound.
     return m_soundManager->stopSound(buffer);
+}
+
+void WorldDocument::CancelSound()
+{
+    // Fire OnPluginPlaySound with the empty string so plugins can suppress the cancel.
+    // If a plugin handles it (returns true), skip the stop entirely — matching the
+    // original CMUSHclientDoc::CancelSound (doc.cpp:7135-7158).
+    if (!m_bInCancelSoundFilePlugin) {
+        m_bInCancelSoundFilePlugin = true;
+        const bool handled = SendToFirstPluginCallbacks(ON_PLUGIN_PLAY_SOUND, QString());
+        m_bInCancelSoundFilePlugin = false;
+        if (handled) {
+            return; // handled by plugin? don't do our own sound cancel
+        }
+    }
+
+    // default sound-cancel mechanism
+    StopSound(0);
 }
 
 bool WorldDocument::PlaySoundFile(const QString& filename)

--- a/src/world/xml_serialization.cpp
+++ b/src/world/xml_serialization.cpp
@@ -22,7 +22,9 @@
 #include <QXmlStreamReader>
 #include <QXmlStreamWriter>
 #include <algorithm> // for std::sort, std::transform
+#include <array>
 #include <string>
+#include <tuple>
 
 namespace {
 
@@ -914,11 +916,61 @@ bool LoadWorldXML(WorldDocument* doc, const QString& filename)
     // Notify all plugins once after batch loading (original: xml_load_world.cpp:473-474)
     doc->PluginListChanged();
 
-    // Mark world as loaded (original: xml_load_world.cpp sets m_bLoaded)
-    doc->m_bLoaded = true;
+    // If defaults are wanted, overwrite what we loaded with them.
+    // Original: CMUSHclientDoc::Serialize calls OnFileReloaddefaults after
+    // Serialize_World_XML on load (serialize.cpp:72).
+    ReloadDefaults(doc);
 
     qCDebug(lcWorld) << "LoadWorldXML: successfully loaded from" << filename;
     return true;
+}
+
+// ============================================================================
+// RELOAD DEFAULT FILES (flag-checked)
+// ============================================================================
+//
+// Original: CMUSHclientDoc::OnFileReloaddefaults (scripting/methods/methods_defaults.cpp),
+// called from CMUSHclientDoc::Serialize after loading a world file (serialize.cpp:72).
+// For each set type, only reloads the configured default file when the matching
+// m_bUseDefault* flag is set AND the path is non-empty.
+int ReloadDefaults(WorldDocument* doc)
+{
+    if (!doc) {
+        qWarning() << "ReloadDefaults: null document";
+        return 0;
+    }
+
+    const auto& opts = GlobalOptions::instance();
+
+    // (flag, configured-path, single-type import flag) — order matches the original.
+    const std::array<std::tuple<bool, QString, int>, 4> defaultSets = {{
+        {doc->m_bUseDefaultTriggers, opts.defaultTriggersFile(), XML_TRIGGERS},
+        {doc->m_bUseDefaultAliases, opts.defaultAliasesFile(), XML_ALIASES},
+        {doc->m_bUseDefaultTimers, opts.defaultTimersFile(), XML_TIMERS},
+        {doc->m_bUseDefaultMacros, opts.defaultMacrosFile(), XML_MACROS},
+    }};
+
+    int totalImported = 0;
+
+    for (const auto& [useDefault, path, flag] : defaultSets) {
+        if (!useDefault || path.isEmpty())
+            continue;
+
+        QFile file(path);
+        if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+            qCWarning(lcWorld) << "ReloadDefaults: could not open default file" << path;
+            continue;
+        }
+
+        int imported = ImportXML(doc, QString::fromUtf8(file.readAll()), flag);
+        if (imported > 0)
+            totalImported += imported;
+    }
+
+    if (totalImported > 0)
+        qCDebug(lcWorld) << "ReloadDefaults: reapplied" << totalImported << "default item(s)";
+
+    return totalImported;
 }
 
 // ============================================================================

--- a/src/world/xml_serialization.h
+++ b/src/world/xml_serialization.h
@@ -76,6 +76,18 @@ bool LoadWorldXML(WorldDocument* doc, const QString& filename);
 // Returns -1 if XML is invalid or parsing fails
 int ImportXML(WorldDocument* doc, const QString& xmlString, int flags = XML_ALL);
 
+// Reapplies configured default files for any set type whose m_bUseDefault* flag
+// is enabled on the document. Mirrors the original CMUSHclientDoc::OnFileReloaddefaults
+// (scripting/methods/methods_defaults.cpp), which is invoked after loading a world
+// file so that default triggers/aliases/timers/macros overwrite what was loaded.
+//
+// Unlike a user-initiated reload, this does NOT force the flags on: a default file is
+// only reloaded when its corresponding m_bUseDefault* flag was already set (typically
+// from the loaded world file) and the configured path is non-empty.
+//
+// Returns the total number of items imported across all reloaded default files.
+int ReloadDefaults(WorldDocument* doc);
+
 // Exports triggers, aliases, timers, variables to an XML string
 // Only exports sections specified by flags bitmask
 //

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -662,6 +662,20 @@ gtest_discover_tests(test-xml-roundtrip-gtest
     DISCOVERY_TIMEOUT 30
 )
 
+# Miniwindow LoadImage parity test (GoogleTest)
+add_executable(test-miniwindow-loadimage-gtest
+    test_miniwindow_loadimage_gtest.cpp
+)
+
+target_link_libraries(test-miniwindow-loadimage-gtest PRIVATE
+    test_main_gui
+    ui
+)
+
+gtest_discover_tests(test-miniwindow-loadimage-gtest
+    DISCOVERY_TIMEOUT 30
+)
+
 # Miniwindow creation test (non-GoogleTest, uses Qt6::Test)
 add_executable(test-miniwindow-creation
     test_miniwindow_creation.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -718,6 +718,23 @@ gtest_discover_tests(test-sound-api-gtest
     DISCOVERY_TIMEOUT 30
 )
 
+# StopSound vs CancelSound parity test (group 4, H8)
+add_executable(test-sound-cancel-gtest
+    test_sound_cancel_gtest.cpp
+)
+
+target_link_libraries(test-sound-cancel-gtest PRIVATE
+    test_main_core
+    Qt6::Gui
+    Qt6::Widgets
+    Qt6::Multimedia
+    ui
+)
+
+gtest_discover_tests(test-sound-cancel-gtest
+    DISCOVERY_TIMEOUT 30
+)
+
 # Unique ID API test
 add_executable(test-unique-id-api-gtest
     test_unique_id_api_gtest.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -630,6 +630,22 @@ gtest_discover_tests(test-options-tables-gtest
     DISCOVERY_TIMEOUT 30
 )
 
+# World properties dialog parity test (Character name field binds to m_name)
+add_executable(test-world-properties-dialog-gtest
+    test_world_properties_dialog_gtest.cpp
+)
+
+target_link_libraries(test-world-properties-dialog-gtest PRIVATE
+    test_main_gui
+    Qt6::Gui
+    Qt6::Widgets
+    ui
+)
+
+gtest_discover_tests(test-world-properties-dialog-gtest
+    DISCOVERY_TIMEOUT 30
+)
+
 # XML roundtrip test
 add_executable(test-xml-roundtrip-gtest
     test_xml_roundtrip_gtest.cpp

--- a/tests/test_command_color_api_gtest.cpp
+++ b/tests/test_command_color_api_gtest.cpp
@@ -238,6 +238,45 @@ TEST_F(CommandColorAPITest, SetCustomColourNameNoChangeIfSame)
     EXPECT_FALSE(doc->m_bModified);
 }
 
+// ========== ColourNameToRGB Tests ==========
+
+// Helper: call ColourNameToRGB(name) and return the lua_Integer it pushed.
+static lua_Integer callColourNameToRGB(lua_State* L, const char* name)
+{
+    lua_getglobal(L, "ColourNameToRGB");
+    lua_pushstring(L, name);
+    EXPECT_EQ(lua_pcall(L, 1, 1, 0), 0)
+        << "ColourNameToRGB error: " << (lua_isstring(L, -1) ? lua_tostring(L, -1) : "");
+    lua_Integer result = lua_tointeger(L, -1);
+    lua_pop(L, 1);
+    return result;
+}
+
+// Unknown color names must return -1 (matches original methods_colours.cpp:31-32),
+// NOT 4294967295 (0xFFFFFFFF reinterpreted as unsigned on 64-bit). Plugins do
+// `if ColourNameToRGB(x) == -1 then ...` and rely on the signed sentinel.
+TEST_F(CommandColorAPITest, ColourNameToRGBUnknownReturnsMinusOne)
+{
+    EXPECT_EQ(callColourNameToRGB(L, "not_a_real_colour"), -1);
+}
+
+// Valid named colors must return their positive BGR value, unchanged by the
+// sign-extension fix (top byte is zero, so they stay positive).
+TEST_F(CommandColorAPITest, ColourNameToRGBKnownReturnsPositiveBGR)
+{
+    // red => BGR(255,0,0) => 0x000000FF
+    EXPECT_EQ(callColourNameToRGB(L, "red"), 0x000000FF);
+    // white => BGR(255,255,255) => 0x00FFFFFF, the largest valid value
+    EXPECT_EQ(callColourNameToRGB(L, "white"), 0x00FFFFFF);
+}
+
+// Hex strings resolve to positive BGR values too (never the -1 sentinel).
+TEST_F(CommandColorAPITest, ColourNameToRGBHexReturnsPositive)
+{
+    // "#0000FF" (HTML blue, RGB) => BGR(0,0,255) => 0x00FF0000
+    EXPECT_EQ(callColourNameToRGB(L, "#0000FF"), 0x00FF0000);
+}
+
 // ========== Utility Function Tests ==========
 
 // Test GetUdpPort (deprecated, always returns 0)

--- a/tests/test_command_color_api_gtest.cpp
+++ b/tests/test_command_color_api_gtest.cpp
@@ -286,3 +286,32 @@ TEST_F(CommandColorAPITest, GetUdpPort)
 
     // No C++ side effects to verify (function always returns 0)
 }
+
+// ========== Font Metric GetInfo Tests ==========
+
+// world.GetInfo() font metrics are derived from the active font on demand, not
+// from a 0-initialized member that is never updated. Original returns
+// tm.tmAveCharWidth / tm.tmHeight (doc.cpp:3258/3323/3324); Mushkin computes
+// these from QFontMetrics. These cases require a GUI app (QFontMetrics needs
+// QGuiApplication), which this binary provides via test_main_gui.
+TEST_F(CommandColorAPITest, GetInfoFontMetricsNonZero)
+{
+    executeLua("output_width = world.GetInfo(213)"); // output font width
+    executeLua("input_height = world.GetInfo(214)"); // input font height
+    executeLua("input_width = world.GetInfo(215)");  // input font width
+    executeLua("avg_width = world.GetInfo(240)");    // average char width
+
+    int outputWidth = getGlobalInt("output_width");
+    int inputHeight = getGlobalInt("input_height");
+    int inputWidth = getGlobalInt("input_width");
+    int avgWidth = getGlobalInt("avg_width");
+
+    EXPECT_GT(outputWidth, 0) << "GetInfo(213) output font width must be non-zero";
+    EXPECT_GT(inputHeight, 0) << "GetInfo(214) input font height must be non-zero";
+    EXPECT_GT(inputWidth, 0) << "GetInfo(215) input font width must be non-zero";
+    EXPECT_GT(avgWidth, 0) << "GetInfo(240) average char width must be non-zero";
+
+    // GetInfo(240) average char width mirrors GetInfo(213) output font width.
+    EXPECT_EQ(avgWidth, outputWidth)
+        << "GetInfo(240) must equal GetInfo(213) (both are output tm.tmAveCharWidth)";
+}

--- a/tests/test_command_execution_gtest.cpp
+++ b/tests/test_command_execution_gtest.cpp
@@ -16,6 +16,7 @@
  * fixtures, and assertion messages.
  */
 
+#include "../src/utils/error_codes.h"
 #include "../src/world/world_document.h"
 #include "fixtures/world_fixtures.h"
 #include <QFile>
@@ -221,4 +222,40 @@ TEST_F(CommandExecutionTest, ImmediateSending)
     // For now, just verify queue is empty
     EXPECT_TRUE(doc->m_connectionManager->m_CommandQueue.isEmpty())
         << "Queue should remain empty with no speedwalk delay";
+}
+
+/**
+ * Test 8: Execute() returns eOK on a normal command
+ *
+ * Mirrors original CMUSHclientDoc::Execute (methods_commands.cpp:398), whose long
+ * return value is pushed to the Lua caller by world.Execute (lua_methods.cpp:2269).
+ */
+TEST_F(CommandExecutionTest, ExecuteReturnsOkForNormalCommand)
+{
+    EXPECT_EQ(doc->Execute("look", true, false), static_cast<long>(eOK))
+        << "A normal command should return eOK";
+    // Depth counter must be balanced after a successful Execute().
+    EXPECT_EQ(doc->m_iExecutionDepth, 0) << "Execution depth should return to 0 after Execute()";
+}
+
+/**
+ * Test 9: Execute() returns eCommandsNestedTooDeeply when the recursion guard fires
+ *
+ * Original (methods_commands.cpp:262-265) returns eCommandsNestedTooDeeply (30041)
+ * once m_iExecutionDepth exceeds MAX_EXECUTION_DEPTH (100). Previously Mushkin's
+ * Execute() returned void and world.Execute always pushed eOK, masking the guard.
+ */
+TEST_F(CommandExecutionTest, ExecuteReturnsNestedTooDeeplyAtDepthLimit)
+{
+    // Pre-load the depth so the next ++ pushes it over MAX_EXECUTION_DEPTH (100).
+    doc->m_iExecutionDepth = 100;
+
+    EXPECT_EQ(doc->Execute("look", true, false), static_cast<long>(eCommandsNestedTooDeeply))
+        << "Exceeding the execution depth limit should return eCommandsNestedTooDeeply";
+
+    // The guard decrements before returning, restoring the pre-call depth.
+    EXPECT_EQ(doc->m_iExecutionDepth, 100)
+        << "Depth guard must decrement back to its pre-call value on the deep path";
+
+    doc->m_iExecutionDepth = 0; // restore for any subsequent tests
 }

--- a/tests/test_lua_api_gtest.cpp
+++ b/tests/test_lua_api_gtest.cpp
@@ -258,3 +258,36 @@ TEST_F(LuaApiTest, DisconnectErrorCodes)
     EXPECT_EQ(resultDisconnecting, static_cast<double>(eWorldClosed))
         << "Disconnect() should return eWorldClosed (30002) when already disconnecting";
 }
+
+// Test 16: API-created object names are keyed in lower case, matching the original
+// CMUSHclientDoc::CheckObjectName() which calls MakeLower() after validation. The
+// AutomationRegistry keys triggers directly off the validated name without any further
+// lowercasing, so validateObjectName() lowercasing is what makes API trigger names
+// case-insensitive. Without it, a mixed-case AddTrigger name would be stored verbatim and
+// only findable with the exact same case.
+TEST_F(LuaApiTest, ObjectNamesKeyedLowerCase)
+{
+    // Create a trigger under a mixed-case name via the Lua API.
+    executeLua("world.AddTrigger('MyTrigger', 'hello', '', 1, 0, 0, '', '', 0, 100)");
+
+    auto& triggerMap = doc->m_automationRegistry->m_TriggerMap;
+
+    // Stored key should be lowercased, not the original case.
+    EXPECT_TRUE(triggerMap.find("mytrigger") != triggerMap.end())
+        << "Trigger should be stored under the lowercased key";
+    EXPECT_TRUE(triggerMap.find("MyTrigger") == triggerMap.end())
+        << "Trigger should NOT be stored under the original-case key";
+
+    // Re-adding with a different case (and no eReplace) must collide with the existing one,
+    // proving the lookup is case-insensitive.
+    executeLua("dup_result = world.AddTrigger('MYTRIGGER', 'world', '', 1, 0, 0, '', '', 0, 100)");
+    EXPECT_EQ(getGlobalNumber("dup_result"), static_cast<double>(eTriggerAlreadyExists))
+        << "Adding a same-named trigger in different case should report it already exists";
+
+    // Deleting under yet another case must succeed and remove the single stored trigger.
+    executeLua("del_result = world.DeleteTrigger('mytrigger')");
+    EXPECT_EQ(getGlobalNumber("del_result"), 0.0)
+        << "DeleteTrigger should find and delete the trigger regardless of name case";
+    EXPECT_TRUE(triggerMap.find("mytrigger") == triggerMap.end())
+        << "Trigger should be gone after case-insensitive delete";
+}

--- a/tests/test_miniwindow_drawing.cpp
+++ b/tests/test_miniwindow_drawing.cpp
@@ -729,6 +729,143 @@ int main(int argc, char* argv[])
 
     qDebug() << "✓ WindowFontList returns correct font list\n";
 
+    // ========== Test 19: WindowCircleOp - invalid brush style (H78) ==========
+    qDebug() << "Test 19: WindowCircleOp - invalid brush style is rejected";
+
+    // Original ValidateBrushStyle accepts only 0-12; anything else returns
+    // eBrushStyleNotValid (30074). Mushkin previously accepted invalid styles silently.
+    if (!executeLua(L, R"(
+        result = world.WindowCircleOp("draw_test",
+                                      miniwin.circle_ellipse,
+                                      10, 60, 50, 100,
+                                      0x00FFFF, miniwin.pen_solid, 1,
+                                      0x000000,
+                                      99,                 -- invalid brush style
+                                      0, 0, 0, 0)
+    )",
+                    "WindowCircleOp invalid brush style")) {
+        return 1;
+    }
+
+    result = getGlobalNumber(L, "result");
+    if (result != static_cast<double>(eBrushStyleNotValid)) {
+        qDebug() << "✗ FAIL: WindowCircleOp should reject invalid brush style with"
+                 << eBrushStyleNotValid << "got" << result;
+        return 1;
+    }
+
+    // A valid brush style (12 = waves-vertical, the upper bound) must still succeed.
+    if (!executeLua(L, R"(
+        result = world.WindowCircleOp("draw_test",
+                                      miniwin.circle_ellipse,
+                                      10, 60, 50, 100,
+                                      0x00FFFF, miniwin.pen_solid, 1,
+                                      0x000000,
+                                      12,                 -- valid (upper bound)
+                                      0, 0, 0, 0)
+    )",
+                    "WindowCircleOp valid brush style 12")) {
+        return 1;
+    }
+
+    result = getGlobalNumber(L, "result");
+    if (result != 0) {
+        qDebug() << "✗ FAIL: WindowCircleOp valid brush style 12 should succeed, got" << result;
+        return 1;
+    }
+
+    qDebug() << "✓ WindowCircleOp validates brush styles (rejects out-of-range, accepts 0-12)\n";
+
+    // ========== Test 20: WindowImageOp - monochrome pattern colour remap (M47) ==========
+    qDebug() << "Test 20: WindowImageOp remaps monochrome pattern colours";
+
+    // Create an 8x8 monochrome pattern that is entirely set bits (all 0xFF rows).
+    // Every pixel is a "1-bit", which GDI paints in the brush colour (text colour).
+    if (!executeLua(L, R"(
+        world.WindowCreateImage("draw_test", "solidpat",
+                                0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF)
+        -- Fill a rectangle using the pattern. brushColor = green (BGR 0x00FF00),
+        -- penColor = red (BGR 0x0000FF). Set bits should appear in brushColor (green).
+        result = world.WindowImageOp("draw_test", 2,          -- 2 = rectangle
+                                     5, 165, 45, 195,         -- left, top, right, bottom
+                                     0x0000FF, miniwin.pen_solid, 1,  -- red pen
+                                     0x00FF00,                -- green brush colour
+                                     "solidpat")
+    )",
+                    "WindowImageOp monochrome remap")) {
+        return 1;
+    }
+
+    result = getGlobalNumber(L, "result");
+    if (result != 0) {
+        qDebug() << "✗ FAIL: WindowImageOp returned" << result;
+        return 1;
+    }
+
+    // The filled interior should now be green (brushColor), not raw white from the pattern.
+    img = (*win->getImage());
+    QRgb patFill = img.pixel(25, 180);
+    if (qGreen(patFill) < 180 || qRed(patFill) > 80 || qBlue(patFill) > 80) {
+        qDebug() << "✗ FAIL: Monochrome pattern not remapped to brush colour; pixel at (25,180) ="
+                 << QString::number(patFill, 16) << "R=" << qRed(patFill) << "G=" << qGreen(patFill)
+                 << "B=" << qBlue(patFill);
+        return 1;
+    }
+
+    qDebug() << "✓ WindowImageOp remaps monochrome 1-bits to brush colour\n";
+
+    // ========== Test 21: WindowArc - ellipse aspect-ratio correction (L88) ==========
+    qDebug() << "Test 21: WindowArc applies ellipse aspect-ratio correction";
+
+    // Use a very flat ellipse: bounding box (0,80)-(200,120), so cx=100, cy=100,
+    // semi-radii a=100, b=20. Endpoints (180,105) and (180,95) straddle the X axis.
+    //  - WITH aspect-ratio correction: Qt span is ~34.7 deg, covering Qt angles
+    //    [-17.35, +17.35] -> the arc reaches out to pixel (~196, ~94) (Qt ~16 deg).
+    //  - WITHOUT correction (the bug): Qt span is only ~7.15 deg, covering
+    //    [-3.58, +3.58]; the arc never leaves the neighbourhood of the right vertex
+    //    (x ~199.8-200), so x=196 is never touched.
+    // Pixel (196, 94) / (196, 106) therefore uniquely distinguishes the corrected
+    // arc from the buggy one. Pen width 3 keeps the stroke tight enough that the
+    // buggy arc cannot bleed out to x=196.
+    if (!executeLua(L, R"(
+        result = world.WindowArc("draw_test",
+                                 0, 80, 200, 120,    -- flat bounding ellipse
+                                 180, 105,           -- start point (below axis)
+                                 180, 95,            -- end point (above axis)
+                                 0x0000FF,           -- red pen (BGR)
+                                 miniwin.pen_solid, 3)
+    )",
+                    "WindowArc ellipse correction")) {
+        return 1;
+    }
+
+    result = getGlobalNumber(L, "result");
+    if (result != 0) {
+        qDebug() << "✗ FAIL: WindowArc returned" << result;
+        return 1;
+    }
+
+    // The buggy (unscaled) arc cannot reach x<=197 here; only the aspect-ratio
+    // corrected arc paints the (196,94)/(196,106) region. Tight +/-1 window.
+    img = (*win->getImage());
+    bool foundArcPixel = false;
+    for (int dy = -1; dy <= 1 && !foundArcPixel; ++dy) {
+        for (int dx = -1; dx <= 1 && !foundArcPixel; ++dx) {
+            QRgb p1 = img.pixel(196 + dx, 94 + dy);
+            QRgb p2 = img.pixel(196 + dx, 106 + dy);
+            if (qRed(p1) > 150 || qRed(p2) > 150)
+                foundArcPixel = true;
+        }
+    }
+
+    if (!foundArcPixel) {
+        qDebug() << "✗ FAIL: WindowArc did not draw through the aspect-ratio-corrected region "
+                    "(~Qt 16 deg, pixel ~196,94); ellipse correction missing";
+        return 1;
+    }
+
+    qDebug() << "✓ WindowArc draws the aspect-ratio-corrected span on a flat ellipse\n";
+
     // ========== All tests passed! ==========
     qDebug() << "\n=== PASS: All tests passed ===\n";
     qDebug() << "Miniwindow Drawing features verified:";
@@ -751,6 +888,9 @@ int main(int argc, char* argv[])
     qDebug() << "  ✓ WindowFontInfo returns correct values";
     qDebug() << "  ✓ Pen and brush style constants available";
     qDebug() << "✓ WindowFontList returns list of fonts";
+    qDebug() << "  ✓ WindowCircleOp rejects invalid brush styles (H78)";
+    qDebug() << "  ✓ WindowImageOp remaps monochrome pattern colours (M47)";
+    qDebug() << "  ✓ WindowArc applies ellipse aspect-ratio correction (L88)";
     qDebug() << "\nFont count:" << win->fonts.size();
 
     return 0;

--- a/tests/test_miniwindow_loadimage_gtest.cpp
+++ b/tests/test_miniwindow_loadimage_gtest.cpp
@@ -1,0 +1,97 @@
+/**
+ * test_miniwindow_loadimage_gtest.cpp - GoogleTest version
+ *
+ * Behavioral-parity tests for MiniWindow::LoadImage (and the Lua wrapper
+ * world.WindowLoadImage which delegates to it).
+ *
+ * Original behavior (miniwindow.cpp:1047-1103, Utilities.cpp:2972-...):
+ *   1. Empty filename removes the image and returns eOK.
+ *   2. Filename shorter than 5 chars returns eBadParameter.
+ *   3. Filename without a .bmp/.png extension returns eBadParameter
+ *      (all other Qt image formats are rejected, matching the original which
+ *      only accepts .bmp and .png).
+ *   4. A .png/.bmp file that does not exist returns eFileNotFound.
+ *   5. A .png/.bmp file that exists but cannot be decoded returns
+ *      eUnableToLoadImage (distinct from eFileNotFound).
+ *   6. A valid .png file loads successfully and returns eOK.
+ */
+
+#include "../src/world/miniwindow.h"
+#include "../src/world/world_document.h"
+#include "fixtures/world_fixtures.h"
+#include <QImage>
+#include <QTemporaryDir>
+#include <memory>
+
+class MiniWindowLoadImageTest : public WorldDocumentTest {
+  protected:
+    void SetUp() override
+    {
+        WorldDocumentTest::SetUp();
+        win = std::make_unique<MiniWindow>(doc.get());
+        ASSERT_TRUE(tempDir.isValid()) << "Temp dir should be created";
+    }
+
+    QString pathIn(const QString& name) const
+    {
+        return tempDir.filePath(name);
+    }
+
+    std::unique_ptr<MiniWindow> win;
+    QTemporaryDir tempDir;
+};
+
+// 1. Empty filename removes the image and returns eOK.
+TEST_F(MiniWindowLoadImageTest, EmptyFilenameRemovesImageAndReturnsOk)
+{
+    EXPECT_EQ(win->LoadImage("img", ""), eOK);
+    EXPECT_EQ(win->LoadImage("img", "   "), eOK); // whitespace trims to empty
+}
+
+// 2. Filename shorter than 5 chars returns eBadParameter (original requires x.bmp length).
+TEST_F(MiniWindowLoadImageTest, ShortFilenameReturnsBadParameter)
+{
+    EXPECT_EQ(win->LoadImage("img", "a.bm"), eBadParameter);
+}
+
+// 3. Non-.bmp/.png extensions are rejected with eBadParameter.
+TEST_F(MiniWindowLoadImageTest, NonBmpPngExtensionReturnsBadParameter)
+{
+    // Create a real, valid JPEG so the rejection is by extension, not by load failure.
+    QImage img(4, 4, QImage::Format_RGB32);
+    img.fill(Qt::red);
+    const QString jpgPath = pathIn("pic.jpg");
+    ASSERT_TRUE(img.save(jpgPath, "JPG")) << "Failed to write test jpg";
+
+    EXPECT_EQ(win->LoadImage("img", jpgPath), eBadParameter);
+}
+
+// 4. A .png that does not exist returns eFileNotFound.
+TEST_F(MiniWindowLoadImageTest, MissingPngReturnsFileNotFound)
+{
+    EXPECT_EQ(win->LoadImage("img", pathIn("does_not_exist.png")), eFileNotFound);
+}
+
+// 5. A .png that exists but is not a valid image returns eUnableToLoadImage.
+TEST_F(MiniWindowLoadImageTest, CorruptPngReturnsUnableToLoadImage)
+{
+    const QString junkPath = pathIn("junk.png");
+    QFile f(junkPath);
+    ASSERT_TRUE(f.open(QIODevice::WriteOnly));
+    f.write("this is not a valid PNG file");
+    f.close();
+
+    EXPECT_EQ(win->LoadImage("img", junkPath), eUnableToLoadImage);
+}
+
+// 6. A valid .png loads successfully.
+TEST_F(MiniWindowLoadImageTest, ValidPngReturnsOk)
+{
+    QImage img(8, 8, QImage::Format_ARGB32);
+    img.fill(Qt::blue);
+    const QString pngPath = pathIn("good.png");
+    ASSERT_TRUE(img.save(pngPath, "PNG")) << "Failed to write test png";
+
+    EXPECT_EQ(win->LoadImage("logo", pngPath), eOK);
+    EXPECT_NE(win->images.find("logo"), win->images.end()) << "Image should be stored";
+}

--- a/tests/test_mxp_gtest.cpp
+++ b/tests/test_mxp_gtest.cpp
@@ -13,6 +13,8 @@
  * 8. Element collection and routing
  */
 
+#include "../src/network/world_socket.h"
+#include "../src/world/connection_manager.h"
 #include "../src/world/mxp_types.h"
 #include "fixtures/world_fixtures.h"
 
@@ -1044,4 +1046,147 @@ TEST_F(MXPTest, HighTagIncreasesColorValues)
     // Should set high intensity flag
     // (Implementation specific)
     SUCCEED();
+}
+
+// ========== Story 6: secure_once parity (H46/H106, M85) ==========
+
+// H46/H106: a secure-only (non-open) tag must be ACCEPTED while in secure_once
+// mode. Original captures bSecure = MXP_Secure() (true for eMXP_secure_once) BEFORE
+// MXP_Restore_Mode() cancels secure-once. The old Mushkin code computed bSecure
+// inline omitting eMXP_secure_once, so it wrongly rejected the tag.
+TEST_F(MXPTest, StartTagAcceptsSecureOnlyTagInSecureOnceMode)
+{
+    // <samp> has flags == 0: not open, not command -> secure-only, tracked in active list.
+    doc->m_mxpEngine->m_iMXP_mode = eMXP_secure_once;
+    doc->m_mxpEngine->m_iMXP_previousMode = eMXP_open;
+
+    const qint64 errorsBefore = doc->m_mxpEngine->mxpErrors();
+    const size_t tagsBefore = doc->m_mxpEngine->m_activeTagList.size();
+
+    doc->m_mxpEngine->m_strMXPstring = "samp";
+    doc->m_mxpEngine->MXP_collected_element();
+
+    // Tag accepted: no new error, pushed onto the active tag list, marked secure.
+    EXPECT_EQ(doc->m_mxpEngine->mxpErrors(), errorsBefore);
+    ASSERT_EQ(doc->m_mxpEngine->m_activeTagList.size(), tagsBefore + 1);
+    EXPECT_EQ(doc->m_mxpEngine->m_activeTagList.back()->strName, "samp");
+    EXPECT_TRUE(doc->m_mxpEngine->m_activeTagList.back()->bSecure);
+
+    // secure_once is cancelled after the tag: mode restored to the previous mode.
+    EXPECT_EQ(doc->m_mxpEngine->m_iMXP_mode, eMXP_open);
+}
+
+// Control: outside secure mode a secure-only tag is still rejected (regression guard
+// that the fix did not make every mode "secure").
+TEST_F(MXPTest, StartTagRejectsSecureOnlyTagInOpenMode)
+{
+    doc->m_mxpEngine->m_iMXP_mode = eMXP_open;
+
+    const qint64 errorsBefore = doc->m_mxpEngine->mxpErrors();
+    const size_t tagsBefore = doc->m_mxpEngine->m_activeTagList.size();
+
+    doc->m_mxpEngine->m_strMXPstring = "samp";
+    doc->m_mxpEngine->MXP_collected_element();
+
+    EXPECT_EQ(doc->m_mxpEngine->mxpErrors(), errorsBefore + 1);
+    EXPECT_EQ(doc->m_mxpEngine->m_activeTagList.size(), tagsBefore);
+}
+
+// H46/H106: EndTag must close a secure tag while in secure_once mode (bSecure must be
+// true for the duration of the close lookup before the mode is restored).
+TEST_F(MXPTest, EndTagClosesSecureTagInSecureOnceMode)
+{
+    // Open a secure tag in full secure mode.
+    doc->m_mxpEngine->m_iMXP_mode = eMXP_secure;
+    doc->m_mxpEngine->m_strMXPstring = "samp";
+    doc->m_mxpEngine->MXP_collected_element();
+    ASSERT_FALSE(doc->m_mxpEngine->m_activeTagList.empty());
+    ASSERT_EQ(doc->m_mxpEngine->m_activeTagList.back()->strName, "samp");
+
+    // Now close it while in secure_once mode — should succeed (tag popped).
+    doc->m_mxpEngine->m_iMXP_mode = eMXP_secure_once;
+    doc->m_mxpEngine->m_iMXP_previousMode = eMXP_open;
+    doc->m_mxpEngine->m_strMXPstring = "/samp";
+    doc->m_mxpEngine->MXP_collected_element();
+
+    EXPECT_TRUE(doc->m_mxpEngine->m_activeTagList.empty());
+}
+
+// M85: an invalid <support> argument (more than two dot-separated components) must
+// suppress the ENTIRE <SUPPORTS> reply (original returns from MXP_OpenAtomicTag with
+// no SendPacket). A valid argument sends exactly one packet.
+TEST_F(MXPTest, SupportInvalidArgumentSendsNoPacket)
+{
+    // Install a socket so SendPacket counts packets (it no-ops without one).
+    auto* socket = new WorldSocket(doc.get(), doc.get());
+    doc->m_connectionManager->m_pSocket = socket;
+
+    AtomicElement* support = doc->m_mxpEngine->MXP_FindAtomicElement("support");
+    ASSERT_NE(support, nullptr);
+
+    // Invalid: three dot-separated components.
+    {
+        MXPArgumentList args;
+        auto arg = std::make_unique<MXPArgument>();
+        arg->strValue = "send.prompt.extra";
+        args.push_back(std::move(arg));
+
+        doc->m_connectionManager->m_iOutputPacketCount = 0;
+        doc->m_mxpEngine->MXP_ExecuteAction(support, args);
+        EXPECT_EQ(doc->m_connectionManager->m_iOutputPacketCount, 0)
+            << "invalid <support> argument must send no packet";
+    }
+
+    // Valid: a single recognised component sends exactly one packet.
+    {
+        MXPArgumentList args;
+        auto arg = std::make_unique<MXPArgument>();
+        arg->strValue = "send";
+        args.push_back(std::move(arg));
+
+        doc->m_connectionManager->m_iOutputPacketCount = 0;
+        doc->m_mxpEngine->MXP_ExecuteAction(support, args);
+        EXPECT_EQ(doc->m_connectionManager->m_iOutputPacketCount, 1)
+            << "valid <support> argument must send exactly one packet";
+    }
+
+    doc->m_connectionManager->m_pSocket = nullptr;
+}
+
+// M85: an invalid <support> tag name also suppresses the reply.
+TEST_F(MXPTest, SupportInvalidTagNameSendsNoPacket)
+{
+    auto* socket = new WorldSocket(doc.get(), doc.get());
+    doc->m_connectionManager->m_pSocket = socket;
+
+    AtomicElement* support = doc->m_mxpEngine->MXP_FindAtomicElement("support");
+    ASSERT_NE(support, nullptr);
+
+    MXPArgumentList args;
+    auto arg = std::make_unique<MXPArgument>();
+    arg->strValue = "1bad"; // does not start with a letter -> invalid name
+    args.push_back(std::move(arg));
+
+    doc->m_connectionManager->m_iOutputPacketCount = 0;
+    doc->m_mxpEngine->MXP_ExecuteAction(support, args);
+    EXPECT_EQ(doc->m_connectionManager->m_iOutputPacketCount, 0);
+
+    doc->m_connectionManager->m_pSocket = nullptr;
+}
+
+// M85: <version> response is sent (the protocol version string was corrected to "0.5").
+TEST_F(MXPTest, VersionActionSendsPacket)
+{
+    auto* socket = new WorldSocket(doc.get(), doc.get());
+    doc->m_connectionManager->m_pSocket = socket;
+
+    AtomicElement* version = doc->m_mxpEngine->MXP_FindAtomicElement("version");
+    ASSERT_NE(version, nullptr);
+
+    MXPArgumentList args;
+    doc->m_connectionManager->m_iOutputPacketCount = 0;
+    doc->m_mxpEngine->MXP_ExecuteAction(version, args);
+    EXPECT_EQ(doc->m_connectionManager->m_iOutputPacketCount, 1);
+
+    doc->m_connectionManager->m_pSocket = nullptr;
 }

--- a/tests/test_options_tables_gtest.cpp
+++ b/tests/test_options_tables_gtest.cpp
@@ -224,6 +224,31 @@ TEST_F(OptionsTableTest, CanFindSpecificNumericOptions)
     }
 }
 
+// ========== Option Default Value Tests ==========
+
+// Test 15: A freshly constructed world logs MUD output by default.
+// Original MUSHclient defaults log_output to true (scriptingoptions.cpp:130).
+// The XML loader leaves absent attributes at their constructor defaults
+// (xml_serialization.cpp:570), so the in-class member initializer is the
+// effective default for new worlds and for saves that omit the attribute.
+TEST_F(OptionsWorldDocumentTest, LogOutputDefaultsToTrue)
+{
+    EXPECT_TRUE(doc->m_logging.log_output)
+        << "New worlds must log MUD output by default (original default: true)";
+
+    // The OptionsTable metadata default must agree with the member initializer.
+    const tConfigurationNumericOption* logOutput = nullptr;
+    for (const tConfigurationNumericOption* opt = OptionsTable; opt->pName != nullptr; opt++) {
+        if (QString(opt->pName) == "log_output") {
+            logOutput = opt;
+            break;
+        }
+    }
+    ASSERT_NE(logOutput, nullptr) << "log_output must exist in OptionsTable";
+    EXPECT_DOUBLE_EQ(logOutput->iDefault, 1.0)
+        << "OptionsTable default for log_output must be true (1.0)";
+}
+
 // Test 14: Can find specific alpha options
 TEST_F(AlphaOptionsTableTest, CanFindSpecificAlphaOptions)
 {

--- a/tests/test_options_tables_gtest.cpp
+++ b/tests/test_options_tables_gtest.cpp
@@ -270,3 +270,74 @@ TEST_F(AlphaOptionsTableTest, CanFindSpecificAlphaOptions)
         }
     }
 }
+
+// ========== MXP Mode Numeric Parity (H123) ==========
+//
+// The "use_mxp" option stores the raw integer value of m_iUseMXP both in the
+// world file and through Lua GetOption/SetOption. Those integers MUST match the
+// original MUSHclient enum (doc.h:350-355):
+//   eOnCommandMXP = 0, eQueryMXP = 1, eUseMXP = 2, eNoMXP = 3.
+// Any other numbering breaks world-file cross-compatibility and Lua parity.
+
+static const tConfigurationNumericOption* findNumericOption(const char* name)
+{
+    for (const tConfigurationNumericOption* opt = OptionsTable; opt->pName != nullptr; opt++) {
+        if (QString(opt->pName) == name) {
+            return opt;
+        }
+    }
+    return nullptr;
+}
+
+// MXPMode enumerators carry the exact original numeric values.
+TEST_F(OptionsTableTest, MxpModeEnumValuesMatchOriginal)
+{
+    EXPECT_EQ(static_cast<int>(MXPMode::eMXP_On), 0) // eOnCommandMXP
+        << "eMXP_On (on command) must serialize as 0 like eOnCommandMXP";
+    EXPECT_EQ(static_cast<int>(MXPMode::eMXP_Query), 1) // eQueryMXP
+        << "eMXP_Query must serialize as 1 like eQueryMXP";
+    EXPECT_EQ(static_cast<int>(MXPMode::eMXP_Always), 2) // eUseMXP
+        << "eMXP_Always (always on) must serialize as 2 like eUseMXP";
+    EXPECT_EQ(static_cast<int>(MXPMode::eMXP_Off), 3) // eNoMXP
+        << "eMXP_Off must serialize as 3 like eNoMXP";
+}
+
+// use_mxp metadata: default is "on command" (0) with the original 0..3 range.
+TEST_F(OptionsTableTest, UseMxpDefaultAndRangeMatchOriginal)
+{
+    const tConfigurationNumericOption* useMxp = findNumericOption("use_mxp");
+    ASSERT_NE(useMxp, nullptr) << "use_mxp must exist in OptionsTable";
+    EXPECT_DOUBLE_EQ(useMxp->iDefault, 0.0) << "use_mxp default must be eOnCommandMXP (0)";
+    EXPECT_DOUBLE_EQ(useMxp->iMinimum, 0.0);
+    EXPECT_DOUBLE_EQ(useMxp->iMaximum, 3.0)
+        << "use_mxp range must span all four original modes (0..3)";
+}
+
+// The getter/setter round-trip every original integer to the matching MXPMode.
+TEST_F(OptionsWorldDocumentTest, UseMxpGetterSetterRoundTripsOriginalIntegers)
+{
+    const tConfigurationNumericOption* useMxp = findNumericOption("use_mxp");
+    ASSERT_NE(useMxp, nullptr);
+
+    // A freshly constructed world defaults to "on command" (0).
+    EXPECT_EQ(static_cast<int>(doc->m_iUseMXP), 0);
+    EXPECT_DOUBLE_EQ(useMxp->getter(*doc), 0.0);
+
+    struct {
+        int value;
+        MXPMode mode;
+    } cases[] = {
+        {0, MXPMode::eMXP_On},
+        {1, MXPMode::eMXP_Query},
+        {2, MXPMode::eMXP_Always},
+        {3, MXPMode::eMXP_Off},
+    };
+
+    for (const auto& c : cases) {
+        useMxp->setter(*doc, static_cast<double>(c.value));
+        EXPECT_EQ(doc->m_iUseMXP, c.mode)
+            << "use_mxp integer " << c.value << " must map to the matching MXPMode";
+        EXPECT_DOUBLE_EQ(useMxp->getter(*doc), static_cast<double>(c.value))
+            << "GetOption(use_mxp) must report the same integer that was set";
+    }
+}

--- a/tests/test_plugin_api_gtest.cpp
+++ b/tests/test_plugin_api_gtest.cpp
@@ -690,3 +690,58 @@ TEST_F(PluginApiTest, ReloadPlugin)
     EXPECT_EQ(plugin1->m_strName, QString("TestPlugin1"))
         << "Reloaded plugin should have correct name";
 }
+
+// Test 24: world.ReloadPlugin fires OnPluginListChanged exactly once (parity M16)
+//
+// Original CMUSHclientDoc::ReloadPlugin removes+deletes the old plugin silently
+// and calls PluginListChanged() exactly once, after InternalLoadPlugin succeeds.
+// Mushkin previously fired it twice (once in UnloadPlugin, once in LoadPlugin),
+// exposing observers to an intermediate "plugin removed" state.
+TEST_F(PluginApiTest, ReloadPlugin_FiresListChangedOnce)
+{
+    // Observer plugin counts OnPluginListChanged invocations.
+    QString observerScript = R"(
+list_changed_count = 0
+function OnPluginListChanged()
+    list_changed_count = list_changed_count + 1
+end
+)";
+    QString observerPath = tempDir->path() + "/observer.xml";
+    {
+        QFile f(observerPath);
+        ASSERT_TRUE(f.open(QIODevice::WriteOnly | QIODevice::Text));
+        f.write(createTestPluginXML("{CCCC0003-0003-0003-0003-000000000003}", "ObserverPlugin",
+                                    observerScript)
+                    .toUtf8());
+        f.close();
+    }
+
+    QString errorMsg;
+    Plugin* observer = doc->LoadPlugin(observerPath, errorMsg);
+    ASSERT_NE(observer, nullptr) << "Could not load observer: " << errorMsg.toStdString();
+    lua_State* obsL = observer->m_ScriptEngine->L;
+
+    // Reset the counter to ignore the list-changed fired by loading the observer itself.
+    lua_pushnumber(obsL, 0);
+    lua_setglobal(obsL, "list_changed_count");
+
+    // Reload plugin2 from the observer's context (a plugin cannot reload itself,
+    // and the observer must stay loaded so its counter survives the reload).
+    doc->m_CurrentPlugin = observer;
+    lua_getglobal(obsL, "world");
+    lua_getfield(obsL, -1, "ReloadPlugin");
+    lua_pushstring(obsL, plugin2->m_strID.toUtf8().constData());
+    lua_call(obsL, 1, 1);
+    int result = lua_tonumber(obsL, -1);
+    lua_pop(obsL, 1);
+    doc->m_CurrentPlugin = nullptr;
+
+    EXPECT_EQ(result, 0) << "ReloadPlugin should return eOK";
+
+    lua_getglobal(obsL, "list_changed_count");
+    int listChangedCount = lua_tonumber(obsL, -1);
+    lua_pop(obsL, 1);
+
+    EXPECT_EQ(listChangedCount, 1)
+        << "OnPluginListChanged must fire exactly once per ReloadPlugin (was firing twice)";
+}

--- a/tests/test_plugin_callbacks_gtest.cpp
+++ b/tests/test_plugin_callbacks_gtest.cpp
@@ -50,6 +50,7 @@ callback_args = {}
 function OnPluginInstall()
   callback_count = callback_count + 1
   callback_args.install = "called"
+  Note("note from OnPluginInstall")
   return true
 end
 
@@ -64,6 +65,7 @@ end
 function OnPluginSend(text)
   callback_count = callback_count + 1
   callback_args.send = text
+  Note("note from OnPluginSend")
   return false  -- Stop propagation
 end
 
@@ -72,6 +74,7 @@ function OnPluginTelnetOption(option, text)
   callback_count = callback_count + 1
   callback_args.telnet_option = option
   callback_args.telnet_text = text
+  Note("note from OnPluginTelnetOption")
   return true
 end
 
@@ -81,6 +84,7 @@ function OnPluginTelnetSubnegotiation(option, suboption, data)
   callback_args.telnet_subneg_option = option
   callback_args.telnet_subneg_suboption = suboption
   callback_args.telnet_subneg_data = data
+  Note("note from OnPluginTelnetSubnegotiation")
   return true
 end
 ]]>
@@ -276,4 +280,66 @@ TEST_F(PluginCallbacksTest, ExecutePluginScript_NonExistentCallback)
     doc->m_CurrentPlugin = nullptr;
 
     EXPECT_TRUE(result) << "Non-existent callback should return true (default = continue)";
+}
+
+// ===========================================================================
+// Deferred-note batching (m_bNotesNotWantedNow) parity tests.
+//
+// Original plugins.cpp sets m_bNotesNotWantedNow=true before the plugin loop
+// and false after, in ALL six SendToAllPluginCallbacks overloads. While the
+// flag is set, Note()/Tell() issued from a callback are queued in
+// m_OutstandingLines instead of being written straight to the output window
+// (output_formatter.cpp:48,99). These overloads do NOT drain the queue
+// themselves (the caller does via OutputOutstandingLines()), so a note issued
+// from a callback must still be present in m_OutstandingLines after the call
+// returns. Before the fix, four overloads never set the flag, so the note was
+// emitted immediately and the queue stayed empty.
+// ===========================================================================
+
+// Test 11: no-args overload batches notes issued from the callback
+TEST_F(PluginCallbacksTest, SendToAllPluginCallbacks_NoArgs_BatchesNotes)
+{
+    doc->m_OutstandingLines.clear();
+
+    doc->SendToAllPluginCallbacks(ON_PLUGIN_INSTALL);
+
+    EXPECT_FALSE(doc->m_OutstandingLines.empty())
+        << "Note from no-args callback should be deferred to the outstanding queue";
+    EXPECT_FALSE(doc->m_bNotesNotWantedNow) << "flag must be reset to false after the call";
+}
+
+// Test 12: string+bool overload batches notes issued from the callback
+TEST_F(PluginCallbacksTest, SendToAllPluginCallbacks_StringBool_BatchesNotes)
+{
+    doc->m_OutstandingLines.clear();
+
+    doc->SendToAllPluginCallbacks(ON_PLUGIN_SEND, "test command", true);
+
+    EXPECT_FALSE(doc->m_OutstandingLines.empty())
+        << "Note from string+bool callback should be deferred to the outstanding queue";
+    EXPECT_FALSE(doc->m_bNotesNotWantedNow) << "flag must be reset to false after the call";
+}
+
+// Test 13: int+string+bool overload batches notes issued from the callback
+TEST_F(PluginCallbacksTest, SendToAllPluginCallbacks_IntStringBool_BatchesNotes)
+{
+    doc->m_OutstandingLines.clear();
+
+    doc->SendToAllPluginCallbacks(ON_PLUGIN_TELNET_OPTION, 24, "terminal-type", false);
+
+    EXPECT_FALSE(doc->m_OutstandingLines.empty())
+        << "Note from int+string callback should be deferred to the outstanding queue";
+    EXPECT_FALSE(doc->m_bNotesNotWantedNow) << "flag must be reset to false after the call";
+}
+
+// Test 14: int+int+string overload batches notes issued from the callback
+TEST_F(PluginCallbacksTest, SendToAllPluginCallbacks_IntIntString_BatchesNotes)
+{
+    doc->m_OutstandingLines.clear();
+
+    doc->SendToAllPluginCallbacks(ON_PLUGIN_TELNET_SUBNEGOTIATION, 86, 1, "compress-data");
+
+    EXPECT_FALSE(doc->m_OutstandingLines.empty())
+        << "Note from int+int+string callback should be deferred to the outstanding queue";
+    EXPECT_FALSE(doc->m_bNotesNotWantedNow) << "flag must be reset to false after the call";
 }

--- a/tests/test_plugin_serialization_gtest.cpp
+++ b/tests/test_plugin_serialization_gtest.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "../src/automation/plugin.h"
+#include "../src/automation/trigger.h"
 #include "../src/world/world_document.h"
 #include "../src/world/xml_serialization.h"
 #include "fixtures/world_fixtures.h"
@@ -61,6 +62,47 @@ Test plugin description
 </muclient>
 )")
                                 .arg(name, id, QString::number(sequence));
+
+        pluginFile.write(pluginXml.toUtf8());
+        pluginFile.close();
+    }
+
+    // Helper to create a test plugin file containing a single trigger with the
+    // given (possibly mixed-case) label.
+    void createPluginFileWithTrigger(const QString& path, const QString& triggerLabel)
+    {
+        QFile pluginFile(path);
+        ASSERT_TRUE(pluginFile.open(QIODevice::WriteOnly | QIODevice::Text))
+            << "Cannot create plugin file: " << path.toStdString();
+
+        QString pluginXml = QString(R"(<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE muclient>
+<muclient>
+<plugin
+   name="TriggerPlugin"
+   author="Test Author"
+   id="33333333333333333333333333333333"
+   language="Lua"
+   purpose="Test plugin with a trigger"
+   save_state="y"
+   date_written="2025-01-01"
+   requires="5.00"
+   version="1.0"
+   sequence="100"
+>
+<triggers>
+  <trigger
+   name="%1"
+   match="hello world"
+   enabled="y"
+   sequence="100"
+  >
+  </trigger>
+</triggers>
+</plugin>
+</muclient>
+)")
+                                .arg(triggerLabel);
 
         pluginFile.write(pluginXml.toUtf8());
         pluginFile.close();
@@ -210,4 +252,33 @@ TEST_F(PluginSerializationTest, VerifyPluginSortingBySequence)
     EXPECT_EQ(doc2.m_PluginList[0]->m_iSequence, -100) << "First plugin sequence should be -100";
 
     EXPECT_EQ(doc2.m_PluginList[1]->m_iSequence, 100) << "Second plugin sequence should be 100";
+}
+
+// Test 7 (H65): A plugin-scoped trigger with a mixed-case label must be stored
+// under a lowercased internal name, matching the original MUSHclient behavior
+// (xml_load_world.cpp:1314 MakeLower). The plugin load path previously
+// re-assigned internal_name from the original-case label, undoing the fix.
+TEST_F(PluginSerializationTest, PluginTriggerLabelIsLowercased)
+{
+    createPluginFileWithTrigger(pluginPath, "MixedCaseLabel");
+
+    WorldDocument doc;
+    QString errorMsg;
+    Plugin* plugin = doc.LoadPlugin(pluginPath, errorMsg);
+    ASSERT_NE(plugin, nullptr) << "LoadPlugin failed: " << errorMsg.toStdString();
+
+    ASSERT_EQ(plugin->m_TriggerMap.size(), 1u) << "Expected exactly one plugin trigger";
+
+    // The map key (internal_name) must be the lowercased label.
+    EXPECT_TRUE(plugin->m_TriggerMap.find("mixedcaselabel") != plugin->m_TriggerMap.end())
+        << "Plugin trigger should be stored under lowercased internal name";
+    EXPECT_TRUE(plugin->m_TriggerMap.find("MixedCaseLabel") == plugin->m_TriggerMap.end())
+        << "Plugin trigger must NOT be stored under original-case label";
+
+    const Trigger* trigger = plugin->m_TriggerMap.begin()->second.get();
+    ASSERT_NE(trigger, nullptr);
+    EXPECT_EQ(trigger->internal_name, QString("mixedcaselabel"))
+        << "internal_name should be lowercased";
+    // The display label is preserved in original case.
+    EXPECT_EQ(trigger->label, QString("MixedCaseLabel")) << "label should preserve original case";
 }

--- a/tests/test_script_loading_gtest.cpp
+++ b/tests/test_script_loading_gtest.cpp
@@ -675,3 +675,52 @@ TEST_F(ScriptLoadingTest, WorldCallbacksNoOpWhenUnregistered)
     lua_State* L = doc->m_ScriptEngine->L;
     EXPECT_EQ(lua_gettop(L), 0) << "Lua stack should be clean after unregistered callbacks";
 }
+
+// Test 35: onWorldClose() invokes the handler named by on_world_close (M75)
+// Original: SaveModified() runs the close script via m_strWorldClose (doc.cpp:4374-4390).
+TEST_F(ScriptLoadingTest, OnWorldCloseInvokesHandler)
+{
+    resetLuaState();
+
+    QString code = R"(
+        world_close_count = 0
+        function OnWorldClose()
+            world_close_count = world_close_count + 1
+        end
+    )";
+    ASSERT_FALSE(doc->m_ScriptEngine->parseLua(code, "OnWorldClose handler"));
+
+    // The handler name is the configurable on_world_close setting (matches original).
+    doc->m_scripting.on_world_close = "OnWorldClose";
+
+    lua_State* L = doc->m_ScriptEngine->L;
+    EXPECT_EQ(readIntGlobal(L, "world_close_count"), 0) << "Handler not yet fired";
+
+    doc->onWorldClose();
+    EXPECT_EQ(readIntGlobal(L, "world_close_count"), 1) << "OnWorldClose should fire exactly once";
+}
+
+// Test 36: onWorldClose() is a no-op when on_world_close is unset (M75)
+// Original: SeeIfHandlerCanExecute("") never reaches a meaningful ExecuteScript.
+TEST_F(ScriptLoadingTest, OnWorldCloseNoOpWhenNameEmpty)
+{
+    resetLuaState();
+
+    QString code = R"(
+        world_close_count = 0
+        function OnWorldClose()
+            world_close_count = world_close_count + 1
+        end
+    )";
+    ASSERT_FALSE(doc->m_ScriptEngine->parseLua(code, "OnWorldClose handler"));
+
+    // No handler name configured — the close callback must not fire.
+    doc->m_scripting.on_world_close = QString();
+    doc->m_dispidWorldClose = 0;
+
+    lua_State* L = doc->m_ScriptEngine->L;
+    EXPECT_NO_THROW(doc->onWorldClose());
+    EXPECT_EQ(readIntGlobal(L, "world_close_count"), 0)
+        << "OnWorldClose must not fire when no handler name is configured";
+    EXPECT_EQ(lua_gettop(L), 0) << "Lua stack should be clean";
+}

--- a/tests/test_script_loading_gtest.cpp
+++ b/tests/test_script_loading_gtest.cpp
@@ -591,3 +591,87 @@ TEST_F(ScriptLoadingTest, MoonScriptErrorHandling)
         doc->m_ScriptEngine->transpileMoonScript(invalidMoon, "Invalid MoonScript");
     EXPECT_TRUE(transpiled.isEmpty()) << "Invalid MoonScript should return empty string";
 }
+
+// ========== World-level Lua callback dispatch (M75) ==========
+// Verifies OnWorldOpen / OnWorldGetFocus / OnWorldLoseFocus are actually invoked at runtime.
+// Original: OpenSession (doc.cpp:902-913), CSendView::OnActivateView (sendvw.cpp:941-978).
+
+// Helper: read an integer global, leaving the stack clean.
+static int readIntGlobal(lua_State* L, const char* name)
+{
+    lua_getglobal(L, name);
+    int value = lua_isnumber(L, -1) ? static_cast<int>(lua_tointeger(L, -1)) : -1;
+    lua_pop(L, 1);
+    return value;
+}
+
+// Test 31: onWorldOpen() invokes the registered OnWorldOpen handler
+TEST_F(ScriptLoadingTest, OnWorldOpenInvokesHandler)
+{
+    resetLuaState();
+
+    QString code = R"(
+        world_open_count = 0
+        function OnWorldOpen()
+            world_open_count = world_open_count + 1
+        end
+    )";
+    ASSERT_FALSE(doc->m_ScriptEngine->parseLua(code, "OnWorldOpen handler"));
+
+    lua_State* L = doc->m_ScriptEngine->L;
+    EXPECT_EQ(readIntGlobal(L, "world_open_count"), 0) << "Handler not yet fired";
+
+    doc->onWorldOpen();
+    EXPECT_EQ(readIntGlobal(L, "world_open_count"), 1) << "OnWorldOpen should fire exactly once";
+}
+
+// Test 32: onWorldGetFocus() invokes the registered OnWorldGetFocus handler
+TEST_F(ScriptLoadingTest, OnWorldGetFocusInvokesHandler)
+{
+    resetLuaState();
+
+    QString code = R"(
+        world_focus_count = 0
+        function OnWorldGetFocus()
+            world_focus_count = world_focus_count + 1
+        end
+    )";
+    ASSERT_FALSE(doc->m_ScriptEngine->parseLua(code, "OnWorldGetFocus handler"));
+
+    lua_State* L = doc->m_ScriptEngine->L;
+    doc->onWorldGetFocus();
+    EXPECT_EQ(readIntGlobal(L, "world_focus_count"), 1) << "OnWorldGetFocus should fire";
+}
+
+// Test 33: onWorldLoseFocus() invokes the registered OnWorldLoseFocus handler
+TEST_F(ScriptLoadingTest, OnWorldLoseFocusInvokesHandler)
+{
+    resetLuaState();
+
+    QString code = R"(
+        world_lose_count = 0
+        function OnWorldLoseFocus()
+            world_lose_count = world_lose_count + 1
+        end
+    )";
+    ASSERT_FALSE(doc->m_ScriptEngine->parseLua(code, "OnWorldLoseFocus handler"));
+
+    lua_State* L = doc->m_ScriptEngine->L;
+    doc->onWorldLoseFocus();
+    EXPECT_EQ(readIntGlobal(L, "world_lose_count"), 1) << "OnWorldLoseFocus should fire";
+}
+
+// Test 34: callbacks are no-ops (no crash) when no handler is registered
+TEST_F(ScriptLoadingTest, WorldCallbacksNoOpWhenUnregistered)
+{
+    resetLuaState();
+
+    // No OnWorldOpen/GetFocus/LoseFocus defined — dispid lookup must yield DISPID_UNKNOWN
+    // and the calls must not throw or leave the Lua stack dirty.
+    EXPECT_NO_THROW(doc->onWorldOpen());
+    EXPECT_NO_THROW(doc->onWorldGetFocus());
+    EXPECT_NO_THROW(doc->onWorldLoseFocus());
+
+    lua_State* L = doc->m_ScriptEngine->L;
+    EXPECT_EQ(lua_gettop(L), 0) << "Lua stack should be clean after unregistered callbacks";
+}

--- a/tests/test_sound_cancel_gtest.cpp
+++ b/tests/test_sound_cancel_gtest.cpp
@@ -1,0 +1,132 @@
+/**
+ * test_sound_cancel_gtest.cpp - StopSound vs CancelSound parity tests
+ *
+ * Behavioral-parity (group 4, target H8) coverage for the split between
+ * StopSound and CancelSound, mirroring original MUSHclient:
+ *
+ *   - CMUSHclientDoc::StopSound (methods_sounds.cpp:361-402) is a pure
+ *     DirectSound buffer stop and fires NO OnPluginPlaySound callback.
+ *   - CMUSHclientDoc::CancelSound (doc.cpp:7135-7158) fires OnPluginPlaySound
+ *     with the empty string; if a plugin handles it, the cancel is skipped.
+ *
+ * The pre-fix Mushkin merged the callback into StopSound(0), so Lua calls to
+ * world.StopSound(0) wrongly fired the plugin callback and always stopped.
+ */
+
+#include "../src/automation/plugin.h"
+#include "../src/world/script_engine.h"
+#include "../src/world/world_document.h"
+#include "fixtures/world_fixtures.h"
+#include <QTemporaryFile>
+
+class SoundCancelTest : public ::testing::Test {
+  protected:
+    void SetUp() override
+    {
+        doc = std::make_unique<WorldDocument>();
+
+        pluginFile = new QTemporaryFile();
+        pluginFile->setFileTemplate("test-sound-plugin-XXXXXX.xml");
+        ASSERT_TRUE(pluginFile->open()) << "Could not create temp file";
+
+        const QString pluginXml = R"(<?xml version="1.0"?>
+<!DOCTYPE muclient>
+<muclient>
+<plugin
+  name="Sound Test Plugin"
+  author="Test Author"
+  id="{abcdef12-1234-1234-1234-123456789abc}"
+  language="Lua"
+  purpose="Test sound callbacks"
+  version="1.0"
+  save_state="n"
+>
+<script>
+<![CDATA[
+playsound_count = 0
+playsound_arg = nil
+
+function OnPluginPlaySound(filename)
+  playsound_count = playsound_count + 1
+  playsound_arg = filename
+end
+]]>
+</script>
+</plugin>
+</muclient>
+)";
+        pluginFile->write(pluginXml.toUtf8());
+        pluginFile->flush();
+
+        QString errorMsg;
+        plugin = doc->LoadPlugin(pluginFile->fileName(), errorMsg);
+        ASSERT_NE(plugin, nullptr) << "Could not load plugin: " << errorMsg.toStdString();
+        ASSERT_NE(plugin->m_ScriptEngine, nullptr) << "Plugin has no script engine";
+        L = plugin->m_ScriptEngine->L;
+    }
+
+    void TearDown() override
+    {
+        delete pluginFile;
+    }
+
+    int playSoundCount()
+    {
+        lua_getglobal(L, "playsound_count");
+        const int n = static_cast<int>(lua_tointeger(L, -1));
+        lua_pop(L, 1);
+        return n;
+    }
+
+    std::unique_ptr<WorldDocument> doc;
+    Plugin* plugin = nullptr;
+    QTemporaryFile* pluginFile = nullptr;
+    lua_State* L = nullptr;
+};
+
+// StopSound(0) must NOT fire OnPluginPlaySound (deviation H8 #1).
+TEST_F(SoundCancelTest, StopSoundDoesNotFireCallback)
+{
+    EXPECT_EQ(playSoundCount(), 0);
+
+    const qint32 result = doc->StopSound(0);
+
+    EXPECT_EQ(result, eOK) << "StopSound(0) should return eOK";
+    EXPECT_EQ(playSoundCount(), 0)
+        << "StopSound(0) must not fire OnPluginPlaySound (that is CancelSound's job)";
+}
+
+// StopSound on a specific buffer must likewise not fire the callback.
+TEST_F(SoundCancelTest, StopSoundBufferDoesNotFireCallback)
+{
+    doc->StopSound(1);
+    EXPECT_EQ(playSoundCount(), 0) << "StopSound(buffer) must not fire OnPluginPlaySound";
+}
+
+// CancelSound() fires OnPluginPlaySound with the empty string (deviation H8 #2).
+TEST_F(SoundCancelTest, CancelSoundFiresCallback)
+{
+    EXPECT_EQ(playSoundCount(), 0);
+
+    doc->CancelSound();
+
+    EXPECT_EQ(playSoundCount(), 1) << "CancelSound() should fire OnPluginPlaySound once";
+
+    // The argument is the empty string (a plugin-cancel signal, not a file).
+    lua_getglobal(L, "playsound_arg");
+    ASSERT_TRUE(lua_isstring(L, -1)) << "OnPluginPlaySound arg should be a string";
+    EXPECT_STREQ(lua_tostring(L, -1), "") << "CancelSound should pass the empty string";
+    lua_pop(L, 1);
+}
+
+// When a plugin defines OnPluginPlaySound, CancelSound treats it as handled and
+// skips its own cancel — but StopSound stays callback-free regardless.
+TEST_F(SoundCancelTest, CancelSoundSuppressedButStopSoundUnaffected)
+{
+    doc->CancelSound();
+    EXPECT_EQ(playSoundCount(), 1) << "CancelSound fires the callback once";
+
+    // StopSound never consults the callback, so the count is unchanged.
+    EXPECT_EQ(doc->StopSound(0), eOK);
+    EXPECT_EQ(playSoundCount(), 1) << "StopSound(0) must leave the callback count untouched";
+}

--- a/tests/test_world_properties_dialog_gtest.cpp
+++ b/tests/test_world_properties_dialog_gtest.cpp
@@ -1,0 +1,83 @@
+// test_world_properties_dialog_gtest.cpp - GoogleTest version
+// World Properties Dialog parity test
+//
+// Verifies the "Character name" field (m_nameEdit) binds to the player name
+// (m_name) rather than the world name (m_mush_name). This mirrors the original
+// MUSHclient CPrefsP21::DoDataExchange, which maps IDC_CHARACTER to m_name
+// (prefspropertypages.cpp:8087). Auto-login (connect_manager) sends
+// "connect <m_name> <password>", so a dialog that stored the entered name into
+// m_mush_name would make auto-login ignore the user-entered character name.
+
+#include "../src/ui/dialogs/world_properties_dialog.h"
+#include "../src/world/world_document.h"
+#include <QLineEdit>
+#include <gtest/gtest.h>
+
+#include <memory>
+
+// Friend of WorldPropertiesDialog (declared in the dialog header) so the test
+// can drive the private load/save round-trip directly.
+class WorldPropertiesDialogParityTest : public ::testing::Test {
+  protected:
+    std::unique_ptr<WorldDocument> doc;
+    std::unique_ptr<WorldPropertiesDialog> dlg;
+
+    void SetUp() override
+    {
+        doc = std::make_unique<WorldDocument>();
+    }
+
+    void makeDialog()
+    {
+        dlg = std::make_unique<WorldPropertiesDialog>(doc.get());
+    }
+
+    // Private-member accessors. Only this fixture is a friend of the dialog;
+    // the TEST_F-generated subclasses are not, so all private access must live
+    // in fixture methods.
+    void loadSettings()
+    {
+        dlg->loadSettings();
+    }
+    void saveSettings()
+    {
+        dlg->saveSettings();
+    }
+    QString nameFieldText() const
+    {
+        return dlg->m_nameEdit->text();
+    }
+    void setNameFieldText(const QString& text)
+    {
+        dlg->m_nameEdit->setText(text);
+    }
+};
+
+// loadSettings() must populate the "Character name" field from m_name (player
+// name), not m_mush_name (world name).
+TEST_F(WorldPropertiesDialogParityTest, CharacterFieldLoadsFromPlayerName)
+{
+    doc->m_name = QStringLiteral("Gandalf");
+    doc->m_mush_name = QStringLiteral("MiddleEarth MUD");
+
+    makeDialog();
+    loadSettings();
+
+    EXPECT_EQ(nameFieldText(), QStringLiteral("Gandalf"));
+    EXPECT_NE(nameFieldText(), QStringLiteral("MiddleEarth MUD"));
+}
+
+// saveSettings() must write the "Character name" field back into m_name and
+// must leave m_mush_name (the world name) untouched.
+TEST_F(WorldPropertiesDialogParityTest, CharacterFieldSavesToPlayerName)
+{
+    doc->m_name = QStringLiteral("OldName");
+    doc->m_mush_name = QStringLiteral("MiddleEarth MUD");
+
+    makeDialog();
+    setNameFieldText(QStringLiteral("Frodo"));
+    saveSettings();
+
+    EXPECT_EQ(doc->m_name, QStringLiteral("Frodo"));
+    EXPECT_EQ(doc->m_mush_name, QStringLiteral("MiddleEarth MUD"));
+}

--- a/tests/test_world_protocol_gtest.cpp
+++ b/tests/test_world_protocol_gtest.cpp
@@ -6,9 +6,11 @@
  * defined in src/world/world_protocol.cpp.
  */
 
+#include "../src/network/world_socket.h"
 #include "../src/text/line.h"
 #include "../src/text/style.h"
 #include "../src/world/color_utils.h"
+#include "../src/world/mxp_engine.h"
 #include "../src/world/telnet_parser.h"
 #include "../src/world/world_document.h"
 #include "fixtures/world_fixtures.h"
@@ -496,4 +498,70 @@ TEST_F(WorldProtocolTest, SendPacket_WithData_DoesNotCrash)
     // SendPacket with data to a non-connected socket should not crash.
     const unsigned char data[] = {0xFF, 0xFB, 0x01};
     EXPECT_NO_FATAL_FAILURE(doc->SendPacket(std::span<const unsigned char>{data, 3}));
+}
+
+// ========== Category 14: M17 — outgoing packet debug dump ==========
+// Original: doc.cpp:5593-5594 — SendPacket dumps the outgoing packet when packet
+// debug is enabled. The hex dump is written to the output window (via colourNote)
+// when no plugin handles ON_PLUGIN_PACKET_DEBUG, so the line list grows.
+
+TEST_F(WorldProtocolTest, SendPacket_DebugOn_EmitsHexDump)
+{
+    auto* socket = new WorldSocket(doc.get(), doc.get());
+    doc->m_connectionManager->m_pSocket = socket;
+    doc->m_bDebugIncomingPackets = true;
+
+    int before = lineCount();
+    const unsigned char data[] = {0xFF, 0xFB, 0x01};
+    doc->SendPacket(std::span<const unsigned char>{data, 3});
+
+    EXPECT_GT(lineCount(), before) << "outgoing packet debug must produce a hex dump in the output";
+
+    doc->m_connectionManager->m_pSocket = nullptr;
+}
+
+TEST_F(WorldProtocolTest, SendPacket_DebugOff_EmitsNoHexDump)
+{
+    auto* socket = new WorldSocket(doc.get(), doc.get());
+    doc->m_connectionManager->m_pSocket = socket;
+    doc->m_bDebugIncomingPackets = false;
+
+    int before = lineCount();
+    const unsigned char data[] = {0xFF, 0xFB, 0x01};
+    doc->SendPacket(std::span<const unsigned char>{data, 3});
+
+    EXPECT_EQ(lineCount(), before)
+        << "with packet debug off, SendPacket must not produce any output";
+
+    doc->m_connectionManager->m_pSocket = nullptr;
+}
+
+// ========== Category 15: M83 — EOL closes MXP tags + reverts line mode ==========
+// Original: doc.cpp:2071-2076 — on '\n', when MXP is active and not in Pueblo mode,
+// close open tags and revert to the default line mode via MXP_mode_change(-1).
+
+TEST_F(WorldProtocolTest, Newline_WhenMXPActive_RevertsToDefaultMode)
+{
+    doc->MXP_On();
+    auto& mxp = *doc->m_mxpEngine;
+    mxp.m_iMXP_defaultMode = eMXP_open; // default after newline
+    mxp.m_iMXP_mode = eMXP_secure;      // currently in a non-default mode
+
+    feed({'\n'});
+
+    EXPECT_EQ(mxp.m_iMXP_mode, mxp.m_iMXP_defaultMode)
+        << "newline must revert MXP to the default line mode";
+}
+
+TEST_F(WorldProtocolTest, Newline_WhenMXPInactive_LeavesModeUnchanged)
+{
+    // MXP off by default — the EOL MXP block must be skipped entirely.
+    auto& mxp = *doc->m_mxpEngine;
+    ASSERT_FALSE(doc->isMXPActive());
+    mxp.m_iMXP_mode = eMXP_secure;
+
+    feed({'\n'});
+
+    EXPECT_EQ(mxp.m_iMXP_mode, eMXP_secure)
+        << "with MXP inactive, newline must not touch the MXP mode";
 }

--- a/tests/test_xml_serialization_gtest.cpp
+++ b/tests/test_xml_serialization_gtest.cpp
@@ -7,6 +7,7 @@
 
 #include "../src/automation/alias.h"
 #include "../src/automation/trigger.h"
+#include "../src/storage/global_options.h"
 #include "../src/world/world_document.h"
 #include "../src/world/xml_serialization.h"
 #include "fixtures/world_fixtures.h"
@@ -466,4 +467,91 @@ TEST_F(XmlSerializationTest, MultipleTriggersAndAliases)
     }
 
     cleanupSaveFiles(filename);
+}
+
+// ============================================================================
+// ReloadDefaults: default files reapplied after world load (parity M26)
+// ============================================================================
+//
+// Original: CMUSHclientDoc::Serialize calls OnFileReloaddefaults after loading a
+// world (serialize.cpp:72), which reapplies each configured default file when the
+// matching m_bUseDefault* flag is set. LoadWorldXML must do the same.
+
+// Writes a minimal default-triggers XML file containing one named trigger and
+// returns its path. The file is removed by cleanupSaveFiles().
+static QString writeDefaultTriggersFile(const QString& triggerName, const QString& pattern)
+{
+    QString path = generateTempFilename("default_triggers");
+    QFile file(path);
+    EXPECT_TRUE(file.open(QIODevice::WriteOnly | QIODevice::Text))
+        << "Failed to write default triggers file";
+    QString xml = QString("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                          "<muclient><triggers>"
+                          "<trigger name=\"%1\" match=\"%2\" enabled=\"y\" sequence=\"100\">"
+                          "<send><![CDATA[do something]]></send>"
+                          "</trigger>"
+                          "</triggers></muclient>\n")
+                      .arg(triggerName, pattern);
+    file.write(xml.toUtf8());
+    file.close();
+    return path;
+}
+
+TEST_F(XmlSerializationTest, ReloadDefaultsReappliesDefaultTriggersOnLoad)
+{
+    // Save/restore the global default-triggers path so we don't pollute other tests.
+    auto& opts = GlobalOptions::instance();
+    const QString savedPath = opts.defaultTriggersFile();
+
+    QString defaultsPath = writeDefaultTriggersFile("default_trig", "Default pattern");
+    opts.setDefaultTriggersFile(defaultsPath);
+
+    // World file with use_default_triggers enabled (round-trips via config options).
+    auto doc1 = std::make_unique<WorldDocument>();
+    doc1->m_mush_name = "Reload Defaults Test";
+    doc1->m_bUseDefaultTriggers = true;
+
+    QString filename = generateTempFilename("reload_defaults");
+    ASSERT_TRUE(XmlSerialization::SaveWorldXML(doc1.get(), filename)) << "SaveWorldXML failed";
+
+    // Loading must reapply the default triggers file.
+    auto doc2 = std::make_unique<WorldDocument>();
+    ASSERT_TRUE(XmlSerialization::LoadWorldXML(doc2.get(), filename)) << "LoadWorldXML failed";
+
+    EXPECT_TRUE(doc2->m_bUseDefaultTriggers) << "use_default_triggers should round-trip";
+    Trigger* loaded = doc2->getTrigger("default_trig");
+    ASSERT_NE(loaded, nullptr) << "Default trigger should be reapplied on load";
+    EXPECT_EQ(loaded->trigger, "Default pattern") << "Default trigger pattern should match";
+
+    opts.setDefaultTriggersFile(savedPath);
+    cleanupSaveFiles(filename);
+    QFile::remove(defaultsPath);
+}
+
+TEST_F(XmlSerializationTest, ReloadDefaultsSkippedWhenFlagDisabled)
+{
+    auto& opts = GlobalOptions::instance();
+    const QString savedPath = opts.defaultTriggersFile();
+
+    QString defaultsPath = writeDefaultTriggersFile("default_trig", "Default pattern");
+    opts.setDefaultTriggersFile(defaultsPath);
+
+    // use_default_triggers stays false: defaults must NOT be reapplied.
+    auto doc1 = std::make_unique<WorldDocument>();
+    doc1->m_mush_name = "No Reload Test";
+    doc1->m_bUseDefaultTriggers = false;
+
+    QString filename = generateTempFilename("no_reload_defaults");
+    ASSERT_TRUE(XmlSerialization::SaveWorldXML(doc1.get(), filename)) << "SaveWorldXML failed";
+
+    auto doc2 = std::make_unique<WorldDocument>();
+    ASSERT_TRUE(XmlSerialization::LoadWorldXML(doc2.get(), filename)) << "LoadWorldXML failed";
+
+    EXPECT_FALSE(doc2->m_bUseDefaultTriggers) << "use_default_triggers should remain false";
+    EXPECT_EQ(doc2->getTrigger("default_trig"), nullptr)
+        << "Default trigger must not be applied when flag is off";
+
+    opts.setDefaultTriggersFile(savedPath);
+    cleanupSaveFiles(filename);
+    QFile::remove(defaultsPath);
 }


### PR DESCRIPTION
## Summary

18 behavioral-parity fixes bringing the port closer to original MUSHclient behavior across sound, plugins, MXP, commands, colors, miniwindows, and connection handling. Each is covered by a regression test.

**Build clean; `ctest` 1050/1050 pass (47 new tests), 0 failures.**

## Fixes (by subsystem)

**Sound** — `H8`: `StopSound(0)` no longer fires `OnPluginPlaySound`; `CancelSound` split out with its own re-entrancy guard and return-value honoring (`3d4daa9`)

**Plugins / output**
- `H11`: `m_bNotesNotWantedNow` batching restored on all 6 `SendToAllPluginCallbacks` overloads (was 2/6) — notes during `OnPluginLineReceived`/`OnPluginSend`/etc. no longer corrupt the in-flight line (`87b684e`)
- `M16`: `ReloadPlugin` fires `PluginListChanged` exactly once (`cc79287`)
- `M75`: `OnWorldOpen/Close/GetFocus/LoseFocus` now dispatched at runtime (`b65cb5f`, `9f15ff9`)

**MXP**
- `H46`/`H106`: `secure_once` included in `MXP_Secure()` — secure-only tags no longer rejected (`4d354e0`)
- `H123`: `MXPMode` enum restored to original `use_mxp` numeric values, all callers rerouted (`a69911a`)
- `M85`: MXP version `0.4`→`0.5`; invalid `<support>` argument suppresses reply (`4d354e0`)
- `M83`: `MXP_CloseOpenTags` + mode change at EOL (`13bafa5`)

**Commands / scripting**
- `H21`: `Execute()` propagates `eCommandsNestedTooDeeply` to the Lua caller (`d717898`)
- `H65`: object names lowercased for case-insensitive keying — API + plugin-XML load (`65725b9`, `ce3190a`)

**Colors / info**
- `H43`: `ColourNameToRGB` returns `-1` (not `UINT_MAX`) for unknown names on 64-bit (`53ddcd1`)
- `H53`: `log_output` defaults to `true` — the table default was never applied to the member; the header initializer wins (`18b2938`)
- `M153`: `GetInfo` font-metric codes 213/214/215/240 compute from the active font instead of stale `0` (`60d94d6`)

**Miniwindows**
- `H78`/`M47`/`L88`: CircleOp brush-style validation, ImageOp colour remap, Arc aspect-ratio correction (`22678a5`)
- `L87`: `WindowLoadImage` delegates to `MiniWindow::LoadImage` for format/extension parity (`a76a7b9`)

**Connection / world**
- `H105`: properties "Character name" field bound to `m_name` so auto-login works (`6a33e63`)
- `M17`: outgoing packet debug dump emitted (`13bafa5`)
- `M26`: default files reapplied after loading a world (`ccd1e8e`)

## Verification

Build (clang 22 / C++26 / Qt 6.9.3) clean; `ctest` **1050/1050** including 47 new GoogleTests (one+ per behavioral change). CI re-validates on Linux/macOS/Windows.

## Notes

- clang-tidy surfaces pre-existing lint on touched files (raw `new` in test fixtures, C-style arrays in the MXP element/entity tables, trailing-return-type suggestions) — none introduced here.
- A further batch of lower-severity parity deviations is queued for follow-up PRs.
