### PR TITLE
docs: add download section + Fedora build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,21 @@ A modern MUD client built with Qt. Mushkin is a cross-platform rewrite of [MUSHc
 
 **Beta** - Core functionality is working across all three platforms. The Lua API is near-complete and tested against MUSHclient for behavioral parity. Many MUSHclient plugins work out of the box.
 
+## Download
+
+Prebuilt, self-contained binaries for macOS, Linux (x86_64), and Windows (x64) are on the [Releases page](https://github.com/justinpopa/mushkin/releases). They bundle everything they need — there are no dependencies to install — so the Linux build runs on any modern distribution (Fedora, Arch, Debian/Ubuntu, …), not just the one it was built on.
+
+```bash
+# Linux
+tar -xzf mushkin-*-linux-x64.tar.gz
+./mushkin/mushkin
+```
+
+- **Windows:** extract the `.zip` and run `mushkin.exe`.
+- **macOS:** extract the `.zip`, then right-click `mushkin.app` → **Open** on first launch (to bypass Gatekeeper).
+
+Prefer to compile it yourself? See [Building](#building) below.
+
 ## Requirements
 
 - **Clang 19+** (22 recommended for full C++26 support)
@@ -91,6 +106,39 @@ cmake --build build --parallel
 export QT_QPA_PLATFORM=xcb  # or wayland
 ./build/bin/mushkin
 ```
+
+### Linux (Fedora)
+
+```bash
+# Toolchain & dependencies
+sudo dnf install -y \
+    clang cmake ninja-build gcc-c++ python3-pip \
+    mesa-libGL-devel libxkbcommon-devel \
+    libxcb-devel xcb-util-cursor-devel xcb-util-keysyms-devel xcb-util-wm-devel \
+    luajit-devel pcre-devel sqlite-devel \
+    openssl-devel zlib-devel libssh-devel \
+    pulseaudio-libs-devel alsa-lib-devel pipewire-devel
+
+# Qt
+pip3 install aqtinstall
+aqt install-qt linux desktop 6.9.3 linux_gcc_64 -m qtmultimedia --outputdir ~/Qt
+
+# Clone and build
+git clone https://github.com/justinpopa/mushkin.git
+cd mushkin
+
+cmake -B build -G Ninja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_C_COMPILER=clang \
+    -DCMAKE_CXX_COMPILER=clang++
+cmake --build build --parallel
+
+# Run
+export QT_QPA_PLATFORM=xcb  # or wayland
+./build/bin/mushkin
+```
+
+> **Note:** the `rex` Lua regex module links against PCRE1 (`pcre-devel`), which ships on current Fedora releases but has been removed from **Rawhide**. On Rawhide, use the prebuilt binary from the [Releases page](https://github.com/justinpopa/mushkin/releases) (it bundles PCRE), or build PCRE 8.x from source first.
 
 ### Windows
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A modern MUD client built with Qt. Mushkin is a cross-platform rewrite of [MUSHc
 
 ## Download
 
-Prebuilt, self-contained binaries for macOS, Linux (x86_64), and Windows (x64) are on the [Releases page](https://github.com/justinpopa/mushkin/releases). They bundle everything they need — there are no dependencies to install — so the Linux build runs on any modern distribution (Fedora, Arch, Debian/Ubuntu, …), not just the one it was built on.
+Prebuilt binaries for macOS, Linux (x86_64), and Windows (x64) are on the [Releases page](https://github.com/justinpopa/mushkin/releases). The macOS and Windows builds are self-contained. The Linux build statically links Qt and bundles its non-system libraries (ICU, PCRE, LuaJIT, SQLite, OpenSSL, …), so it runs across distributions — Fedora, Arch, Debian/Ubuntu, … — and needs only a standard desktop environment's shared libraries (X11/Wayland, OpenGL, fontconfig, audio), which any Linux desktop already provides.
 
 ```bash
 # Linux


### PR DESCRIPTION
Addresses #51 (Fedora user couldn't build — Rawhide has dropped PCRE1).

The root cause was discoverability: the README only documented building from source, so a user who just needed to *run* Mushkin went down the build path and hit the missing `libpcre` (PCRE1) dependency. There's already a self-contained Linux tarball on the Releases page that bundles PCRE and runs on any modern distro.

- **Adds a Download section** pointing to the prebuilt, dependency-free binaries (macOS / Linux / Windows).
- **Adds a Fedora build-from-source section** (`dnf` packages, `clang`), with a note that `pcre-devel` (PCRE1) is gone from Rawhide — Rawhide users should grab the prebuilt binary or build PCRE 8.x first.

Docs only. Closes #51.