### PR TITLE
fix: make the Linux static build produce a working desktop binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,6 +104,8 @@ jobs:
             libxcb-keysyms1-dev libxcb-shape0-dev libxcb-xfixes0-dev \
             libxcb-sync-dev libxcb-randr0-dev libxcb-render-util0-dev \
             libxcb-image0-dev libxcb-glx0-dev libxcb-shm0-dev \
+            libxcb-render0-dev libxcb-util-dev libxcb-xinerama0-dev libxcb-xkb-dev \
+            libxkbcommon-x11-dev \
             libfontconfig1-dev libfreetype6-dev libx11-dev libx11-xcb-dev \
             libxext-dev libxfixes-dev libxi-dev libxrender-dev \
             libatspi2.0-dev libglib2.0-dev \
@@ -116,9 +118,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/mushkin/Qt-static
-          # v5: rebuild static Qt with xcb enabled (-feature-xcb); the v4 cache
-          # was built without the xcb platform plugin → eglfs-only binary.
-          key: qt-static-6.9.3-linux-x64-v5
+          # v6: rebuild static Qt with xcb enabled (-feature-xcb). v4 had no xcb
+          # plugin (eglfs-only binary); v5 failed configure (missing xcb syslibs
+          # incl. xkbcommon-x11) and may have cached a partial tree, so bump again.
+          key: qt-static-6.9.3-linux-x64-v6
 
       - name: Build Static Binary
         run: ./scripts/build-linux-static.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,10 +126,11 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/mushkin/Qt-static
-          # v6: rebuild static Qt with xcb enabled (-feature-xcb). v4 had no xcb
-          # plugin (eglfs-only binary); v5 failed configure (missing xcb syslibs
-          # incl. xkbcommon-x11) and may have cached a partial tree, so bump again.
-          key: qt-static-6.9.3-linux-x64-v6
+          # v7: static Qt with xcb enabled and the mysql/psql/odbc SQL drivers
+          # disabled. v4 had no xcb (eglfs-only); v6 built xcb but auto-linked the
+          # MySQL/Postgres driver plugins, adding hard libmysqlclient/libpq deps
+          # Fedora doesn't ship. Bump to discard the v6 tree.
+          key: qt-static-6.9.3-linux-x64-v7
 
       - name: Build Static Binary
         run: ./scripts/build-linux-static.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,6 +110,14 @@ jobs:
             libxext-dev libxfixes-dev libxi-dev libxrender-dev \
             libatspi2.0-dev libglib2.0-dev \
             libpulse-dev libasound2-dev libpipewire-0.3-dev
+          # Clang 22 for C++26 — build-linux-static.sh selects it via find_clang();
+          # without a clang-19..22 present it falls back to gcc, which cannot
+          # configure the C++26 project (Qt's FindWrapAtomic try_compile fails).
+          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
+          echo "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-22 main" | \
+            sudo tee /etc/apt/sources.list.d/llvm.list
+          sudo apt-get update
+          sudo apt-get install -y clang-22
           python3 -m pip install --break-system-packages aqtinstall
           echo "$HOME/.local/bin" >> $GITHUB_PATH
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,7 +116,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/mushkin/Qt-static
-          key: qt-static-6.9.3-linux-x64-v4
+          # v5: rebuild static Qt with xcb enabled (-feature-xcb); the v4 cache
+          # was built without the xcb platform plugin → eglfs-only binary.
+          key: qt-static-6.9.3-linux-x64-v5
 
       - name: Build Static Binary
         run: ./scripts/build-linux-static.sh

--- a/scripts/build-linux-static.sh
+++ b/scripts/build-linux-static.sh
@@ -12,6 +12,8 @@
 #       libxcb-keysyms1-dev libxcb-shape0-dev libxcb-xfixes0-dev \
 #       libxcb-sync-dev libxcb-randr0-dev libxcb-render-util0-dev \
 #       libxcb-image0-dev libxcb-glx0-dev libxcb-shm0-dev \
+#       libxcb-render0-dev libxcb-util-dev libxcb-xinerama0-dev libxcb-xkb-dev \
+#       libxkbcommon-x11-dev \
 #       libfontconfig1-dev libfreetype6-dev libx11-dev libx11-xcb-dev \
 #       libxext-dev libxfixes-dev libxi-dev libxrender-dev \
 #       libatspi2.0-dev libglib2.0-dev

--- a/scripts/build-linux-static.sh
+++ b/scripts/build-linux-static.sh
@@ -150,7 +150,8 @@ build_static_qt() {
         -submodules qtbase,qtmultimedia,qtsvg,qtshadertools \
         -skip qtdeclarative -skip qtquick3d \
         -nomake examples -nomake tests \
-        -no-pch
+        -no-pch \
+        -feature-xcb
 
     # Build & install
     cmake --build . --parallel "$NUM_CORES"
@@ -197,9 +198,21 @@ bundle_dylibs() {
     local lib_dir="$BUILD_DIR/lib"
     mkdir -p "$lib_dir"
 
-    # Whitelist of libraries to bundle (these are the non-system deps)
+    # Whitelist of libraries to bundle (these are the non-system deps).
+    #
+    # ICU is version-pinned: the binary links libicu*.so.<N> for the exact ICU
+    # major it was built against (74 on Ubuntu 24.04). Other distros ship a
+    # different ICU major (e.g. Fedora 44 = 77), so without bundling these the
+    # app fails to start with "libicuuc.so.74: cannot open shared object file".
+    # libpcre2-16 (Qt's UTF-16 regex) is also not always present on minimal
+    # systems. Do NOT bundle libpcre2-8: glib/selinux link it system-wide and a
+    # shadowed copy triggers "no version information available".
     local whitelist=(
         "libpcre.so"
+        "libpcre2-16.so"
+        "libicui18n.so"
+        "libicuuc.so"
+        "libicudata.so"
         "libluajit-5.1.so"
         "libsqlite3.so"
         "libssl.so"

--- a/scripts/build-linux-static.sh
+++ b/scripts/build-linux-static.sh
@@ -153,7 +153,8 @@ build_static_qt() {
         -skip qtdeclarative -skip qtquick3d \
         -nomake examples -nomake tests \
         -no-pch \
-        -feature-xcb
+        -feature-xcb \
+        -no-feature-sql-mysql -no-feature-sql-psql -no-feature-sql-odbc
 
     # Build & install
     cmake --build . --parallel "$NUM_CORES"


### PR DESCRIPTION
## Summary

The Linux release binary could not open a window on a normal desktop. It registered only EGLFS platform plugins (embedded/DRM) and failed at startup with *"Could not find the Qt platform plugin 'xcb'"*. Separately, it crashed on distros with a different ICU major (e.g. Fedora) because ICU was not bundled. This makes the Linux static build actually usable on a desktop.

## Root causes

1. **No xcb platform plugin.** `build-linux-static.sh` configured Qt without `-feature-xcb`, so when the xcb system-library set was incomplete the build *silently* fell back to EGLFS instead of failing. The xcb dev set in CI was also missing `libxkbcommon-x11-dev`, `libxcb-render0-dev`, `libxcb-util-dev`, `libxcb-xinerama0-dev`, and `libxcb-xkb-dev`, so `TEST_xcb_syslibs` was false and the xcb plugin was never built. The static Qt was additionally cached (`v4`) from before any of this, so every release reused the broken tree.
2. **ICU not bundled.** The binary links `libicu*.so.<major>` for the exact ICU it was built against (74 on Ubuntu 24.04); other distros ship a different major (Fedora 44 = 77), so it failed with `libicuuc.so.74: cannot open shared object file`.

## Changes

- Add `-feature-xcb` to the static Qt configure so a missing xcb dependency **fails the build loudly** instead of silently degrading to EGLFS.
- Install the complete xcb dev library set in CI (`libxkbcommon-x11-dev`, `libxcb-render0-dev`, `libxcb-util-dev`, `libxcb-xinerama0-dev`, `libxcb-xkb-dev`).
- Bump the static-Qt cache key (`v4` → `v6`) to force a rebuild with xcb.
- Bundle `libicu{i18n,uc,data}.so` and `libpcre2-16.so` in the dynamic-lib whitelist. **Not** `libpcre2-8` (glib/selinux link it system-wide; a shadowed copy breaks symbol versioning).

## Verification

Built via the Release workflow on this branch (clean static-Qt rebuild). Tested in an amd64 Fedora 44 container with a Workstation-like desktop lib set, system ICU left at 77 (not 74):

- Static plugins: `QXcbIntegrationPlugin` now registered (the old build registered only `QEglFS*`); SQL drivers reduced to `QSQLiteDriverPlugin` only (no more `QMYSQL`/`QPSQL`).
- `ldd ./mushkin`: all dependencies resolved; ICU resolves to the bundled `lib/libicuuc.so.74`.
- Launched under `Xvfb` with `QT_QPA_PLATFORM=xcb`: the app reached its event loop (theme applied, toolbar SVGs rendered) and ran until the test timeout — a real GUI launch, no platform-plugin or missing-library failure.

Note: the tarball statically links Qt and bundles its non-system libraries; it still relies on a standard Linux desktop's shared libraries (X11/xcb, OpenGL, fontconfig, audio), as any GUI app does.
