### PR TITLE
fix: make the macOS and Windows release builds work in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,14 @@ jobs:
           brew install cmake ninja llvm pcre luajit sqlite openssl libssh aqtinstall
           brew link --overwrite certifi aqtinstall 2>/dev/null || true
 
+      - name: Select full Xcode
+        run: |
+          # build-macos-static.sh requires full Xcode (Metal framework headers for
+          # the static Qt build); the runner defaults xcode-select to the Command
+          # Line Tools, which fails its prerequisite check.
+          sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+          xcodebuild -version
+
       - name: Cache Qt Static
         id: cache-qt
         uses: actions/cache@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -205,6 +205,13 @@ jobs:
         run: |
           choco install ninja -y
           pip install aqtinstall
+          # Bump CMake: the runner's 3.31 cannot enable C++26 for clang-cl
+          # (static-Qt FindWrapAtomic try_compile fails). The pip wheel ships a
+          # newer CMake; prepend its bin dir to PATH for subsequent steps.
+          pip install --upgrade cmake
+          $cmakeBin = python -c "import cmake, os; print(os.path.join(os.path.dirname(cmake.__file__), 'data', 'bin'))"
+          Add-Content -Path $env:GITHUB_PATH -Value $cmakeBin
+          & "$cmakeBin\cmake.exe" --version
           if (!(Test-Path "C:\vcpkg")) {
             git clone https://github.com/microsoft/vcpkg.git C:\vcpkg
             C:\vcpkg\bootstrap-vcpkg.bat

--- a/scripts/build-macos-static.sh
+++ b/scripts/build-macos-static.sh
@@ -146,7 +146,8 @@ build_static_qt() {
         -submodules qtbase,qtmultimedia,qtsvg,qtshadertools \
         -skip qtdeclarative -skip qtquick3d \
         -nomake examples -nomake tests \
-        -no-pch
+        -no-pch \
+        -no-feature-sql-mysql -no-feature-sql-psql -no-feature-sql-odbc
 
     # Build & install
     cmake --build . --parallel "$NUM_CORES"

--- a/scripts/build-windows-static.ps1
+++ b/scripts/build-windows-static.ps1
@@ -183,7 +183,8 @@ function Build-Mushkin {
         -DCMAKE_TOOLCHAIN_FILE="$vcpkgToolchain" `
         -DVCPKG_TARGET_TRIPLET=x64-windows `
         -DCMAKE_C_COMPILER=clang-cl `
-        -DCMAKE_CXX_COMPILER=clang-cl
+        -DCMAKE_CXX_COMPILER=clang-cl `
+        -DCMAKE_CXX_EXTENSIONS=OFF
 
     if ($LASTEXITCODE -ne 0) { throw "CMake configure failed" }
 


### PR DESCRIPTION
## Summary

The macOS release build aborted in ~40s, in `build-macos-static.sh`'s prerequisite check: the runner's `xcode-select` points at the Command Line Tools, but the static Qt build needs **full Xcode** (Metal framework headers). Add a step to select the installed Xcode.

Also disable the **mysql/psql/odbc** Qt SQL drivers — GitHub's macOS runners ship PostgreSQL, so Qt would otherwise auto-build the QPSQL driver and add a `libpq` dependency. The app only uses SQLite. Mirrors the Linux fix in #60.

## Verification

Built via the Release workflow on this branch — macOS job green (build + package + upload). The resulting `mushkin.app` is arm64, code-signed, and self-contained: the Homebrew libraries (`libssh`, `libsqlite3`, `libluajit`, `libpcre`, `libcrypto`) are bundled in `Contents/Frameworks` and referenced via `@rpath`; everything else is system frameworks. No `/opt/homebrew` absolute references.

---

## Windows

The Windows static build (clang-cl) reached the app's `find_package(Qt6)` and failed at Qt's `FindWrapAtomic` `try_compile`. Two parts:

1. The project requests C++26 with the default `CMAKE_CXX_EXTENSIONS=ON` (`gnu++2c`), which clang-cl's MSVC frontend doesn't support → pass `-DCMAKE_CXX_EXTENSIONS=OFF` for the Windows app configure (plain `c++2c`).
2. The runner's **CMake 3.31** still couldn't map C++26 to a clang-cl flag (the MSVC-frontend mapping is newer). Install a current CMake via the pip wheel (**4.3.2**) and prepend it to PATH.

With both, clang-cl compiles the C++26 sources and links `mushkin.exe`. Scoped to Windows; Linux/macOS keep their working defaults.

## Verification

Dispatch run with all three platforms green: **macOS, Linux, and Windows builds succeed** (build + package + upload). macOS `.app` validated as a self-contained arm64 bundle (Homebrew libs in `Contents/Frameworks` via `@rpath`); Linux validated launching under Fedora in #60. Windows compiles + links `mushkin.exe` under clang-cl with C++26.