### PR TITLE
fix: macOS app fails to launch — missing Frameworks rpath

### DIFF
--- a/scripts/build-macos-static.sh
+++ b/scripts/build-macos-static.sh
@@ -285,6 +285,18 @@ bundle_dylibs() {
         install_name_tool -change "$ref" "@rpath/$ref_name" "$binary" 2>/dev/null || true
     done
 
+    # Point @rpath at the bundled Frameworks. The references above are now
+    # @rpath/<dylib>, but the only LC_RPATH entries baked in by the build are the
+    # CI cache dir and Homebrew paths, which don't exist on a user's machine — so
+    # the app aborts at launch with "Library not loaded: @rpath/libsqlite3...".
+    # Drop those build-time rpaths and add the bundle's Frameworks dir. Must run
+    # before codesign, since install_name_tool invalidates the signature.
+    echo_info "Fixing main binary rpath..."
+    for rp in $(otool -l "$binary" | awk '/LC_RPATH/{f=1} f&&/path /{print $2; f=0}'); do
+        install_name_tool -delete_rpath "$rp" "$binary" 2>/dev/null || true
+    done
+    install_name_tool -add_rpath "@executable_path/../Frameworks" "$binary" 2>/dev/null || true
+
     # Fix Lua .so modules in Contents/MacOS/lib/
     echo_info "Fixing Lua module references..."
     if [ -d "$lib_dir" ]; then


### PR DESCRIPTION
The v0.5.0 macOS `.app` aborts at launch: `Library not loaded: @rpath/libsqlite3.3.53.1.dylib` (dyld, "Library missing").

`build-macos-static.sh` rewrites the binary's dylib refs to `@rpath/<lib>` and copies the libs into `Contents/Frameworks`, but never adds an `LC_RPATH` pointing at Frameworks — the only rpaths present are the CI cache dir and Homebrew paths, absent on a user's machine. Fix: drop the build-time rpaths and add `@executable_path/../Frameworks` (before codesign, which `install_name_tool` otherwise invalidates).

Verified locally: applying this to the published v0.5.0 `.app` makes it launch and run, with Frameworks as its only rpath (no Homebrew needed).