### PR TITLE
fix: Windows build imports libpq.dll (unused Postgres SQL driver)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -223,7 +223,11 @@ jobs:
         uses: actions/cache@v4
         with:
           path: C:/Users/runneradmin/AppData/Local/mushkin/Qt-static
-          key: qt-static-6.9.3-windows-x64-v7
+          # v8: rebuild static Qt without the mysql/psql/odbc SQL drivers. The
+          # runner ships PostgreSQL, so Qt auto-built QPSQL and the binary
+          # imported libpq.dll (not shipped) → fails to launch. The app uses
+          # only SQLite.
+          key: qt-static-6.9.3-windows-x64-v8
 
       - name: Build Static Binary
         run: |

--- a/scripts/build-windows-static.ps1
+++ b/scripts/build-windows-static.ps1
@@ -144,6 +144,7 @@ function Build-StaticQt {
         -skip qtdeclarative -skip qtquick3d `
         -nomake examples -nomake tests `
         -no-pch `
+        -no-feature-sql-mysql -no-feature-sql-psql -no-feature-sql-odbc `
         -- -DSQLite3_ROOT="$vcpkgInstalled" -DFEATURE_system_sqlite=ON -DCMAKE_OBJECT_PATH_MAX=350 `
         -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl
 


### PR DESCRIPTION
`mushkin.exe` imports `libpq.dll` (PostgreSQL client) which isn't shipped in the package, so it would fail to launch with "libpq.dll not found."

Cause: the Windows runner has PostgreSQL preinstalled, so Qt's `configure` auto-detected it and built the **QPSQL** SQL driver plugin. In a static build, linking `Qt6::Sql` pulls that plugin in, which links `libpq.dll`. Mushkin only uses **SQLite** (prefs DB + `lsqlite3`), so the Postgres/MySQL/ODBC drivers are unwanted.

Fix: pass `-no-feature-sql-mysql -no-feature-sql-psql -no-feature-sql-odbc` to the Windows Qt configure, and bump the Windows Qt cache key (v7→v8) so Qt rebuilds without QPSQL. Mirrors the same fix already applied to Linux (#60) and macOS (#61).

Found via static import analysis of the v0.5.0 `mushkin.exe`; not yet runtime-validated on Windows.